### PR TITLE
[Fix] soft delete 구조 정리, 쿼리 자동화, 로그 추가

### DIFF
--- a/src/main/java/com/roomlog/analysis/domain/Analysis.java
+++ b/src/main/java/com/roomlog/analysis/domain/Analysis.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "analysis")
 @Getter
@@ -40,6 +42,7 @@ public class Analysis {
     @Column(nullable = false)
     private Status status;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/src/main/java/com/roomlog/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/com/roomlog/analysis/repository/AnalysisRepository.java
@@ -10,9 +10,9 @@ import java.util.Optional;
 
 public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
 
-    @Query("SELECT a FROM Analysis a WHERE (a.inRoomId = :roomId OR a.outRoomId = :roomId) AND a.isDeleted = false")
+    @Query("SELECT a FROM Analysis a WHERE a.inRoomId = :roomId OR a.outRoomId = :roomId")
     List<Analysis> findByRoomId(@Param("roomId") Long roomId);
 
-    @Query("SELECT a FROM Analysis a WHERE (a.inRoomId = :roomId OR a.outRoomId = :roomId) AND a.isDeleted = false ORDER BY a.createdAt DESC LIMIT 1")
+    @Query("SELECT a FROM Analysis a WHERE (a.inRoomId = :roomId OR a.outRoomId = :roomId) ORDER BY a.createdAt DESC LIMIT 1")
     Optional<Analysis> findLatestByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/roomlog/defect/domain/Defect.java
+++ b/src/main/java/com/roomlog/defect/domain/Defect.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "defect")
 @Getter
@@ -55,6 +57,7 @@ public class Defect {
     @Column
     private Float z;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/src/main/java/com/roomlog/estimate/domain/Estimate.java
+++ b/src/main/java/com/roomlog/estimate/domain/Estimate.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "estimate")
 @Getter
@@ -52,6 +54,7 @@ public class Estimate {
     @Column
     private String message;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/src/main/java/com/roomlog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/roomlog/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.roomlog.global.exception;
 
 import com.roomlog.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -29,6 +31,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
         return ResponseEntity
                 .status(ErrorCode.COMMON_500.getHttpStatus())
                 .body(ApiResponse.failure(ErrorCode.COMMON_500));

--- a/src/main/java/com/roomlog/repair/domain/Repair.java
+++ b/src/main/java/com/roomlog/repair/domain/Repair.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "repair")
 @Getter
@@ -43,6 +45,7 @@ public class Repair {
     @Column
     private String note;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/src/main/java/com/roomlog/room/domain/Room.java
+++ b/src/main/java/com/roomlog/room/domain/Room.java
@@ -5,10 +5,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "room")
 @Getter
@@ -38,6 +40,7 @@ public class Room {
     @Column(name = "thumbnail_url")
     private String thumbnailUrl;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/src/main/java/com/roomlog/room/repository/RoomRepository.java
+++ b/src/main/java/com/roomlog/room/repository/RoomRepository.java
@@ -1,7 +1,10 @@
 package com.roomlog.room.repository;
 
 import com.roomlog.room.domain.Room;
+import com.roomlog.scan.domain.Scan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +14,8 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     List<Room> findByUserId(Long userId);
 
     Optional<Room> findByIdAndUserId(Long id, Long userId);
+
+    // V02: 입주/퇴거 스캔 타입 기준 방 목록 조회
+    @Query("SELECT r FROM Room r JOIN Scan s ON s.roomId = r.id WHERE r.userId = :userId AND s.scanType = :scanType")
+    List<Room> findByUserIdAndScanType(@Param("userId") Long userId, @Param("scanType") Scan.ScanType scanType);
 }

--- a/src/main/java/com/roomlog/scan/domain/Scan.java
+++ b/src/main/java/com/roomlog/scan/domain/Scan.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "scan")
 @Getter
@@ -22,7 +24,7 @@ public class Scan {
     @Column(name = "scan_id")
     private Long id;
 
-    @Column(name = "room_id", unique = true)
+    @Column(name = "room_id")
     private Long roomId;
 
     @Column(name = "file_url")
@@ -39,6 +41,7 @@ public class Scan {
     @Column(name = "scan_type", nullable = false)
     private ScanType scanType;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/src/main/java/com/roomlog/user/domain/User.java
+++ b/src/main/java/com/roomlog/user/domain/User.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+@SQLRestriction("is_deleted = false")
 @Entity
 @Table(name = "user")
 @Getter


### PR DESCRIPTION
## 📌 작업 내용
- soft delete 조회 쿼리에 자동으로 처리 500 에러 발생 시 디버깅 검증 코드 추가 등

## 🛠 변경 사항
- soft delete 조회 쿼리에 자동으로 처리
- 500 에러 발생 시 디버깅 검증 코드 추가
- 방 한 개에 스캔은 하나만 가능하지만 삭제 후 다시 생성할 수 있도록 unique 조건 제거
- isDeleted 어노테이션이 자동으로 처리하도록 수정

## 🔗 관련 이슈
- Closes #

## ✅ 테스트
- [x] 정상 동작 확인
- [x] 에러 케이스 확인

## 📸 결과 (선택)
- 