### PR TITLE
[Feat] viewer 기능 구현

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -33,6 +33,7 @@ deleted_at datetime [null] // 삭제 시각
 
 Table Scan {
 scan_id int [pk, increment] // 스캔 ID
+user_id int [ref: > User.user_id] // 사용자 FK
 room_id int [ref: > Room.room_id, null] // 방 FK
 file_url varchar [null] // 3D 파일 URL
 status varchar // SCANNING / COMPLETED / FAILED

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -60,7 +60,7 @@ Table Defect {
 defect_id int [pk, increment] // 하자 ID
 analysis_id int [ref: > Analysis.analysis_id] // 분석 FK
 type varchar // 하자 유형
-severity varchar // 심각도 (LOW / MID / HIGH)
+severity varchar // 심각도 (LOW / MEDIUM / HIGH)
 location varchar // 사람이 읽는 위치 설명
 area float // 면적
 estimated_cost int // 예상 비용
@@ -118,4 +118,9 @@ Table RepairDefect {
 repair_defect_id int [pk, increment] // 매핑 ID
 repair_id int [ref: > Repair.repair_id] // 수리 FK
 defect_id int [ref: > Defect.defect_id] // 하자 FK
+}
+
+Table DefectUnitPrice {
+defect_type varchar [pk] // 하자 유형 (SCRATCH / CRACK / PEELING / STAIN / BREAKAGE)
+unit_price int // 단가 (원/m²)
 }

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -15,6 +15,7 @@ SCAN_001 : 존재하지 않는 스캔입니다. #404 Not Found
 SCAN_004 : 스캔이 아직 완료되지 않았습니다. #400 Bad Request
 
 ANALYSIS_001 : 분석 결과가 존재하지 않습니다. #404 Not Found
+ANALYSIS_002: 이미 처리된 분석입니다. #400 Bad Request
 ANALYSIS_003 : 선택한 스캔 조합이 올바르지 않거나 비교 가능한 스캔이 부족합니다. #400 Bad Request
 ANALYSIS_004 : 분석이 아직 완료되지 않았습니다. #400 Bad Request
 

--- a/docs/FEATURE_SPEC.md
+++ b/docs/FEATURE_SPEC.md
@@ -34,7 +34,7 @@
 
 ⸻
 
-1. Home (메인)
+1. Home
 
 H01 - 메인 대시보드 조회
 •	API: GET /rooms
@@ -92,7 +92,7 @@ soft delete 처리 (scan, analysis, defect, estimate, repair 포함)
 
 ⸻
 
-2. Scan (3D 스캔)
+2. Scan
 
 S04 - 스캔 업로드
 •	API: POST /scans
@@ -104,9 +104,9 @@ LiDAR 스캔 결과 업로드 (임시 저장)
 S05 - 방 생성
 •	API: POST /rooms
 •	설명:
-scan_type(IN/OUT)과 함께 room 생성
-→ scan 연결
-→ room당 scan 1개
+방 정보를 생성하고, 업로드된 scan을 해당 room에 연결한다.
+각 room은 생성 시 하나의 scan과 연결된다.
+
 
 ⸻
 
@@ -122,7 +122,7 @@ S07 - 스캔 미리보기
 
 ⸻
 
-3. Viewer (3D 조회 / 비교)
+3. Viewer
 
 V01 - 3D Viewer
 •	API: GET /scans/{scanId}/viewer
@@ -134,18 +134,17 @@ V01 - 3D Viewer
 V02 - 비교 시점 선택
 •	API:
 
-GET /rooms?scanType=IN
-GET /rooms?scanType=OUT
+GET /rooms/{roomId}/scan
 
-	•	설명:
-입주/퇴거 room 선택
+•	설명:
+특정 방에 연결된 전체 스캔 목록(IN/OUT)을 조회한다. 입주/퇴거 비교 대상 선택 시 사용한다.
 
 ⸻
 
 V02-1 - 분석 생성
 •	API: POST /analyses
 •	설명:
-in/out room 기반 scan 비교 분석 생성
+같은 room 내에서 선택한 in_scan과 out_scan을 비교하여 분석을 생성한다.
 
 ⸻
 
@@ -166,16 +165,16 @@ V06 - 수리비 요약
 
 ⸻
 
-4. Defect (하자)
+4. Defect
 
 D01 - 방 하자 목록 조회
 •	API: GET /rooms/{roomId}/defects
 •	설명:
-room 기준 하자 리스트 조회
+해당 room의 최신 analysis 기준 하자 리스트를 조회한다.
 
 ⸻
 
-5. 수리 업체 추천
+5. Repair
 
 R01 - 업체 리스트 조회
 •	API:
@@ -220,10 +219,10 @@ R05 - 수리 내역 조회
 R06 - 수리 완료 등록
 •	API:
 
-PATCH /estimates/{estimateId}/complete
+POST /estimates/{estimateId}/repairs
 
-	•	설명:
-estimate 기반 repair 생성
+•	설명:
+estimate를 기반으로 repair 이력을 생성한다.
 
 ⸻
 

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -1,5 +1,6 @@
 package com.roomlog.analysis.controller;
 
+import com.roomlog.analysis.dto.AiResultRequest;
 import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
 import com.roomlog.analysis.dto.GetAnalysisCostResponse;
@@ -20,6 +21,16 @@ import org.springframework.web.bind.annotation.*;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
+
+    @Operation(summary = "AI 분석 결과 수신 (내부 전용)", description = "AI 서버가 분석 완료 후 하자 목록을 전송하는 내부 API입니다. X-Api-Key 헤더 인증이 필요합니다.", tags = "0. Internal")
+    @PostMapping("/{analysisId}/result")
+    public ApiResponse<Void> receiveAiResult(
+            @Parameter(description = "분석 ID") @PathVariable Long analysisId,
+            @RequestBody AiResultRequest request) {
+
+        analysisService.receiveAiResult(analysisId, request);
+        return ApiResponse.success(200, "분석 결과가 반영되었습니다.", null);
+    }
 
     @Operation(summary = "V02-1. 분석 생성", description = "입주(IN) 스캔과 퇴거(OUT) 스캔을 비교하여 하자 분석을 생성합니다. 분석은 PENDING 상태로 생성되며 AI 처리 완료 후 COMPLETED로 변경됩니다.", tags = "3. Viewer")
     @PostMapping

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -2,6 +2,7 @@ package com.roomlog.analysis.controller;
 
 import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
+import com.roomlog.analysis.dto.GetAnalysisCostResponse;
 import com.roomlog.analysis.dto.GetAnalysisResponse;
 import com.roomlog.analysis.service.AnalysisService;
 import com.roomlog.global.response.ApiResponse;
@@ -28,6 +29,16 @@ public class AnalysisController {
 
         CreateAnalysisResponse response = analysisService.createAnalysis(loginUser.userId(), request);
         return ApiResponse.success(201, "하자 분석 생성에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "V06. 수리비 요약 조회", description = "분석 ID로 하자 유형별 예상 수리비 요약을 조회합니다. COMPLETED 상태의 분석만 조회할 수 있습니다.", tags = "3. Viewer")
+    @GetMapping("/{analysisId}/cost")
+    public ApiResponse<GetAnalysisCostResponse> getAnalysisCost(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "조회할 분석 ID", example = "5") @PathVariable Long analysisId) {
+
+        GetAnalysisCostResponse response = analysisService.getAnalysisCost(loginUser.userId(), analysisId);
+        return ApiResponse.success(200, "수리비 요약 조회에 성공했습니다.", response);
     }
 
     @Operation(summary = "V03. 분석 결과 조회", description = "분석 ID로 하자 분석 결과를 조회합니다. COMPLETED 상태의 분석만 조회할 수 있습니다.", tags = "3. Viewer")

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -8,13 +8,11 @@ import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "5. 분석", description = "하자 분석 생성, 결과 조회 API")
 @RestController
 @RequestMapping("/analyses")
 @RequiredArgsConstructor
@@ -22,7 +20,7 @@ public class AnalysisController {
 
     private final AnalysisService analysisService;
 
-    @Operation(summary = "V02-1. 분석 생성", description = "입주(IN) 스캔과 퇴거(OUT) 스캔을 비교하여 하자 분석을 생성합니다. 분석은 PENDING 상태로 생성되며 AI 처리 완료 후 COMPLETED로 변경됩니다.")
+    @Operation(summary = "V02-1. 분석 생성", description = "입주(IN) 스캔과 퇴거(OUT) 스캔을 비교하여 하자 분석을 생성합니다. 분석은 PENDING 상태로 생성되며 AI 처리 완료 후 COMPLETED로 변경됩니다.", tags = "3. Viewer")
     @PostMapping
     public ApiResponse<CreateAnalysisResponse> createAnalysis(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -32,7 +30,7 @@ public class AnalysisController {
         return ApiResponse.success(201, "하자 분석 생성에 성공했습니다.", response);
     }
 
-    @Operation(summary = "V03. 분석 결과 조회", description = "분석 ID로 하자 분석 결과를 조회합니다. COMPLETED 상태의 분석만 조회할 수 있습니다.")
+    @Operation(summary = "V03. 분석 결과 조회", description = "분석 ID로 하자 분석 결과를 조회합니다. COMPLETED 상태의 분석만 조회할 수 있습니다.", tags = "3. Viewer")
     @GetMapping("/{analysisId}")
     public ApiResponse<GetAnalysisResponse> getAnalysis(
             @AuthenticationPrincipal LoginUser loginUser,

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -1,11 +1,42 @@
 package com.roomlog.analysis.controller;
 
+import com.roomlog.analysis.dto.CreateAnalysisRequest;
+import com.roomlog.analysis.dto.CreateAnalysisResponse;
+import com.roomlog.analysis.service.AnalysisService;
+import com.roomlog.global.response.ApiResponse;
+import com.roomlog.global.security.LoginUser;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "5. 분석", description = "분석 생성, 결과 조회, 수리비 요약 API")
 @RestController
 @RequestMapping("/analyses")
+@RequiredArgsConstructor
 public class AnalysisController {
+
+    private final AnalysisService analysisService;
+
+    @Operation(
+            summary = "V02-1. 분석 생성",
+            description = """
+                    입주(IN) 스캔과 퇴거(OUT) 스캔을 비교하여 하자 분석을 생성합니다.
+
+                    - in_scan_id는 scanType이 IN인 스캔, out_scan_id는 OUT인 스캔이어야 합니다.
+                    - 두 스캔 모두 COMPLETED 상태여야 합니다.
+                    - 스캔 조합이 올바르지 않으면 400(ANALYSIS_003) 에러가 반환됩니다.
+                    - 분석은 PENDING 상태로 생성되며, 이후 AI 처리를 통해 결과가 채워집니다.
+                    """
+    )
+    @PostMapping
+    public ApiResponse<CreateAnalysisResponse> createAnalysis(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Valid @RequestBody CreateAnalysisRequest request) {
+
+        CreateAnalysisResponse response = analysisService.createAnalysis(loginUser.userId(), request);
+        return ApiResponse.success(201, "하자 분석 생성에 성공했습니다.", response);
+    }
 }

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -2,10 +2,12 @@ package com.roomlog.analysis.controller;
 
 import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
+import com.roomlog.analysis.dto.GetAnalysisResponse;
 import com.roomlog.analysis.service.AnalysisService;
 import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,25 @@ import org.springframework.web.bind.annotation.*;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
+
+    @Operation(
+            summary = "V03. 분석 결과 조회",
+            description = """
+                    분석 ID로 생성된 하자 분석 결과를 조회합니다.
+
+                    - 분석 상태가 COMPLETED인 경우에만 조회 가능합니다.
+                    - 상태가 COMPLETED가 아닌 경우 400(ANALYSIS_004) 에러가 반환됩니다.
+                    - 하자 리스트와 심각도별 요약 정보(high/mid/low 건수, 총 예상 수리비)를 함께 반환합니다.
+                    """
+    )
+    @GetMapping("/{analysisId}")
+    public ApiResponse<GetAnalysisResponse> getAnalysis(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "조회할 분석 ID", example = "5") @PathVariable Long analysisId) {
+
+        GetAnalysisResponse response = analysisService.getAnalysis(loginUser.userId(), analysisId);
+        return ApiResponse.success(200, "분석 결과 조회에 성공했습니다.", response);
+    }
 
     @Operation(
             summary = "V02-1. 분석 생성",

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "5. 분석", description = "분석 생성, 결과 조회, 수리비 요약 API")
+@Tag(name = "5. 분석", description = "하자 분석 생성, 결과 조회 API")
 @RestController
 @RequestMapping("/analyses")
 @RequiredArgsConstructor
@@ -22,36 +22,7 @@ public class AnalysisController {
 
     private final AnalysisService analysisService;
 
-    @Operation(
-            summary = "V03. 분석 결과 조회",
-            description = """
-                    분석 ID로 생성된 하자 분석 결과를 조회합니다.
-
-                    - 분석 상태가 COMPLETED인 경우에만 조회 가능합니다.
-                    - 상태가 COMPLETED가 아닌 경우 400(ANALYSIS_004) 에러가 반환됩니다.
-                    - 하자 리스트와 심각도별 요약 정보(high/mid/low 건수, 총 예상 수리비)를 함께 반환합니다.
-                    """
-    )
-    @GetMapping("/{analysisId}")
-    public ApiResponse<GetAnalysisResponse> getAnalysis(
-            @AuthenticationPrincipal LoginUser loginUser,
-            @Parameter(description = "조회할 분석 ID", example = "5") @PathVariable Long analysisId) {
-
-        GetAnalysisResponse response = analysisService.getAnalysis(loginUser.userId(), analysisId);
-        return ApiResponse.success(200, "분석 결과 조회에 성공했습니다.", response);
-    }
-
-    @Operation(
-            summary = "V02-1. 분석 생성",
-            description = """
-                    입주(IN) 스캔과 퇴거(OUT) 스캔을 비교하여 하자 분석을 생성합니다.
-
-                    - in_scan_id는 scanType이 IN인 스캔, out_scan_id는 OUT인 스캔이어야 합니다.
-                    - 두 스캔 모두 COMPLETED 상태여야 합니다.
-                    - 스캔 조합이 올바르지 않으면 400(ANALYSIS_003) 에러가 반환됩니다.
-                    - 분석은 PENDING 상태로 생성되며, 이후 AI 처리를 통해 결과가 채워집니다.
-                    """
-    )
+    @Operation(summary = "V02-1. 분석 생성", description = "입주(IN) 스캔과 퇴거(OUT) 스캔을 비교하여 하자 분석을 생성합니다. 분석은 PENDING 상태로 생성되며 AI 처리 완료 후 COMPLETED로 변경됩니다.")
     @PostMapping
     public ApiResponse<CreateAnalysisResponse> createAnalysis(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -59,5 +30,15 @@ public class AnalysisController {
 
         CreateAnalysisResponse response = analysisService.createAnalysis(loginUser.userId(), request);
         return ApiResponse.success(201, "하자 분석 생성에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "V03. 분석 결과 조회", description = "분석 ID로 하자 분석 결과를 조회합니다. COMPLETED 상태의 분석만 조회할 수 있습니다.")
+    @GetMapping("/{analysisId}")
+    public ApiResponse<GetAnalysisResponse> getAnalysis(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "조회할 분석 ID", example = "5") @PathVariable Long analysisId) {
+
+        GetAnalysisResponse response = analysisService.getAnalysis(loginUser.userId(), analysisId);
+        return ApiResponse.success(200, "분석 결과 조회에 성공했습니다.", response);
     }
 }

--- a/src/main/java/com/roomlog/analysis/dto/AiResultRequest.java
+++ b/src/main/java/com/roomlog/analysis/dto/AiResultRequest.java
@@ -1,0 +1,36 @@
+package com.roomlog.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class AiResultRequest {
+
+    private boolean success;
+    private List<DefectItem> defects;
+
+    @Getter
+    @NoArgsConstructor
+    public static class DefectItem {
+
+        private String type;
+        private String severity;
+        private String location;
+        private Float area;
+        private String description;
+
+        @JsonProperty("before_image_url")
+        private String beforeImageUrl;
+
+        @JsonProperty("after_image_url")
+        private String afterImageUrl;
+
+        private Float x;
+        private Float y;
+        private Float z;
+    }
+}

--- a/src/main/java/com/roomlog/analysis/dto/CreateAnalysisRequest.java
+++ b/src/main/java/com/roomlog/analysis/dto/CreateAnalysisRequest.java
@@ -1,4 +1,21 @@
 package com.roomlog.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
 public class CreateAnalysisRequest {
+
+    @NotNull
+    @JsonProperty("room_id")
+    private Long roomId;
+
+    @NotNull
+    @JsonProperty("in_scan_id")
+    private Long inScanId;
+
+    @NotNull
+    @JsonProperty("out_scan_id")
+    private Long outScanId;
 }

--- a/src/main/java/com/roomlog/analysis/dto/CreateAnalysisResponse.java
+++ b/src/main/java/com/roomlog/analysis/dto/CreateAnalysisResponse.java
@@ -1,4 +1,50 @@
 package com.roomlog.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.analysis.domain.Analysis;
+import com.roomlog.scan.domain.Scan;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class CreateAnalysisResponse {
+
+    @JsonProperty("analysis_id")
+    private final Long analysisId;
+
+    @JsonProperty("room_id")
+    private final Long roomId;
+
+    @JsonProperty("in_room_id")
+    private final Long inRoomId;
+
+    @JsonProperty("out_room_id")
+    private final Long outRoomId;
+
+    @JsonProperty("in_scan_id")
+    private final Long inScanId;
+
+    @JsonProperty("out_scan_id")
+    private final Long outScanId;
+
+    private final String status;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    private CreateAnalysisResponse(Analysis analysis, Scan inScan, Scan outScan) {
+        this.analysisId = analysis.getId();
+        this.roomId = analysis.getRoomId();
+        this.inRoomId = inScan.getRoomId();
+        this.outRoomId = outScan.getRoomId();
+        this.inScanId = analysis.getInScanId();
+        this.outScanId = analysis.getOutScanId();
+        this.status = analysis.getStatus().name();
+        this.createdAt = analysis.getCreatedAt();
+    }
+
+    public static CreateAnalysisResponse of(Analysis analysis, Scan inScan, Scan outScan) {
+        return new CreateAnalysisResponse(analysis, inScan, outScan);
+    }
 }

--- a/src/main/java/com/roomlog/analysis/dto/GetAnalysisCostResponse.java
+++ b/src/main/java/com/roomlog/analysis/dto/GetAnalysisCostResponse.java
@@ -1,4 +1,58 @@
 package com.roomlog.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.defect.domain.Defect;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
 public class GetAnalysisCostResponse {
+
+    @JsonProperty("analysis_id")
+    private final Long analysisId;
+
+    @JsonProperty("total_cost")
+    private final int totalCost;
+
+    @JsonProperty("cost_breakdown")
+    private final List<CostBreakdownItem> costBreakdown;
+
+    private GetAnalysisCostResponse(Long analysisId, List<Defect> defects) {
+        this.analysisId = analysisId;
+        this.totalCost = defects.stream().mapToInt(Defect::getEstimatedCost).sum();
+        this.costBreakdown = defects.stream()
+                .collect(Collectors.groupingBy(Defect::getType))
+                .entrySet().stream()
+                .map(CostBreakdownItem::from)
+                .toList();
+    }
+
+    public static GetAnalysisCostResponse of(Long analysisId, List<Defect> defects) {
+        return new GetAnalysisCostResponse(analysisId, defects);
+    }
+
+    @Getter
+    public static class CostBreakdownItem {
+
+        private final String type;
+        private final int count;
+        private final int cost;
+
+        private CostBreakdownItem(String type, int count, int cost) {
+            this.type = type;
+            this.count = count;
+            this.cost = cost;
+        }
+
+        public static CostBreakdownItem from(Map.Entry<String, List<Defect>> entry) {
+            return new CostBreakdownItem(
+                    entry.getKey(),
+                    entry.getValue().size(),
+                    entry.getValue().stream().mapToInt(Defect::getEstimatedCost).sum()
+            );
+        }
+    }
 }

--- a/src/main/java/com/roomlog/analysis/dto/GetAnalysisResponse.java
+++ b/src/main/java/com/roomlog/analysis/dto/GetAnalysisResponse.java
@@ -1,4 +1,72 @@
 package com.roomlog.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.analysis.domain.Analysis;
+import com.roomlog.defect.dto.DefectItemResponse;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
 public class GetAnalysisResponse {
+
+    @JsonProperty("analysis_id")
+    private final Long analysisId;
+
+    @JsonProperty("room_id")
+    private final Long roomId;
+
+    private final String status;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    private final Summary summary;
+
+    private final List<DefectItemResponse> defects;
+
+    private GetAnalysisResponse(Analysis analysis, List<DefectItemResponse> defects) {
+        this.analysisId = analysis.getId();
+        this.roomId = analysis.getRoomId();
+        this.status = analysis.getStatus().name();
+        this.createdAt = analysis.getCreatedAt();
+        this.defects = defects;
+        this.summary = Summary.from(analysis, defects);
+    }
+
+    public static GetAnalysisResponse of(Analysis analysis, List<DefectItemResponse> defects) {
+        return new GetAnalysisResponse(analysis, defects);
+    }
+
+    @Getter
+    public static class Summary {
+
+        @JsonProperty("defect_count")
+        private final int defectCount;
+
+        @JsonProperty("total_cost")
+        private final int totalCost;
+
+        @JsonProperty("high_count")
+        private final long highCount;
+
+        @JsonProperty("mid_count")
+        private final long midCount;
+
+        @JsonProperty("low_count")
+        private final long lowCount;
+
+        private Summary(Analysis analysis, List<DefectItemResponse> defects) {
+            this.defectCount = defects.size();
+            this.totalCost = analysis.getTotalCost() != null ? analysis.getTotalCost() : 0;
+            this.highCount = defects.stream().filter(d -> "HIGH".equalsIgnoreCase(d.getSeverity())).count();
+            this.midCount = defects.stream().filter(d -> "MEDIUM".equalsIgnoreCase(d.getSeverity()) || "MID".equalsIgnoreCase(d.getSeverity())).count();
+            this.lowCount = defects.stream().filter(d -> "LOW".equalsIgnoreCase(d.getSeverity())).count();
+        }
+
+        public static Summary from(Analysis analysis, List<DefectItemResponse> defects) {
+            return new Summary(analysis, defects);
+        }
+    }
 }

--- a/src/main/java/com/roomlog/analysis/service/AnalysisService.java
+++ b/src/main/java/com/roomlog/analysis/service/AnalysisService.java
@@ -3,7 +3,9 @@ package com.roomlog.analysis.service;
 import com.roomlog.analysis.domain.Analysis;
 import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
+import com.roomlog.analysis.dto.GetAnalysisCostResponse;
 import com.roomlog.analysis.dto.GetAnalysisResponse;
+import com.roomlog.defect.domain.Defect;
 import com.roomlog.analysis.repository.AnalysisRepository;
 import com.roomlog.defect.dto.DefectItemResponse;
 import com.roomlog.defect.repository.DefectRepository;
@@ -50,6 +52,27 @@ public class AnalysisService {
                 .toList();
 
         return GetAnalysisResponse.of(analysis, defects);
+    }
+
+    @Transactional(readOnly = true)
+    public GetAnalysisCostResponse getAnalysisCost(Long userId, Long analysisId) {
+        Analysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_001));
+
+        Room room = roomRepository.findById(analysis.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        if (analysis.getStatus() != Analysis.Status.COMPLETED) {
+            throw new CustomException(ErrorCode.ANALYSIS_004);
+        }
+
+        List<Defect> defects = defectRepository.findByAnalysisId(analysisId);
+
+        return GetAnalysisCostResponse.of(analysisId, defects);
     }
 
     @Transactional

--- a/src/main/java/com/roomlog/analysis/service/AnalysisService.java
+++ b/src/main/java/com/roomlog/analysis/service/AnalysisService.java
@@ -1,14 +1,18 @@
 package com.roomlog.analysis.service;
 
 import com.roomlog.analysis.domain.Analysis;
+import com.roomlog.analysis.dto.AiResultRequest;
 import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
 import com.roomlog.analysis.dto.GetAnalysisCostResponse;
 import com.roomlog.analysis.dto.GetAnalysisResponse;
 import com.roomlog.defect.domain.Defect;
+import com.roomlog.defect.domain.DefectUnitPrice;
+import com.roomlog.defect.domain.SeverityMultiplier;
 import com.roomlog.analysis.repository.AnalysisRepository;
 import com.roomlog.defect.dto.DefectItemResponse;
 import com.roomlog.defect.repository.DefectRepository;
+import com.roomlog.defect.repository.DefectUnitPriceRepository;
 import com.roomlog.global.exception.CustomException;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.room.domain.Room;
@@ -29,6 +33,7 @@ public class AnalysisService {
     private final RoomRepository roomRepository;
     private final ScanRepository scanRepository;
     private final DefectRepository defectRepository;
+    private final DefectUnitPriceRepository defectUnitPriceRepository;
 
     @Transactional(readOnly = true)
     public GetAnalysisResponse getAnalysis(Long userId, Long analysisId) {
@@ -73,6 +78,51 @@ public class AnalysisService {
         List<Defect> defects = defectRepository.findByAnalysisId(analysisId);
 
         return GetAnalysisCostResponse.of(analysisId, defects);
+    }
+
+    @Transactional
+    public void receiveAiResult(Long analysisId, AiResultRequest request) {
+        Analysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_001));
+
+        if (analysis.getStatus() != Analysis.Status.PENDING) {
+            throw new CustomException(ErrorCode.ANALYSIS_002);
+        }
+
+        if (!request.isSuccess()) {
+            analysis.fail();
+            return;
+        }
+
+        List<Defect> defects = request.getDefects().stream()
+                .map(item -> {
+                    DefectUnitPrice unitPrice = defectUnitPriceRepository.findById(item.getType())
+                            .orElseThrow(() -> new CustomException(ErrorCode.COMMON_400));
+
+                    SeverityMultiplier severity = SeverityMultiplier.valueOf(item.getSeverity());
+                    int estimatedCost = (int) Math.ceil(unitPrice.getUnitPrice() * item.getArea() * severity.getMultiplier());
+
+                    return Defect.builder()
+                            .analysisId(analysisId)
+                            .type(item.getType())
+                            .severity(item.getSeverity())
+                            .location(item.getLocation())
+                            .area(item.getArea())
+                            .estimatedCost(estimatedCost)
+                            .beforeImageUrl(item.getBeforeImageUrl())
+                            .afterImageUrl(item.getAfterImageUrl())
+                            .description(item.getDescription())
+                            .x(item.getX())
+                            .y(item.getY())
+                            .z(item.getZ())
+                            .build();
+                })
+                .toList();
+
+        defectRepository.saveAll(defects);
+
+        int totalCost = defects.stream().mapToInt(Defect::getEstimatedCost).sum();
+        analysis.complete(totalCost);
     }
 
     @Transactional

--- a/src/main/java/com/roomlog/analysis/service/AnalysisService.java
+++ b/src/main/java/com/roomlog/analysis/service/AnalysisService.java
@@ -3,7 +3,10 @@ package com.roomlog.analysis.service;
 import com.roomlog.analysis.domain.Analysis;
 import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
+import com.roomlog.analysis.dto.GetAnalysisResponse;
 import com.roomlog.analysis.repository.AnalysisRepository;
+import com.roomlog.defect.dto.DefectItemResponse;
+import com.roomlog.defect.repository.DefectRepository;
 import com.roomlog.global.exception.CustomException;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.room.domain.Room;
@@ -14,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AnalysisService {
@@ -21,6 +26,31 @@ public class AnalysisService {
     private final AnalysisRepository analysisRepository;
     private final RoomRepository roomRepository;
     private final ScanRepository scanRepository;
+    private final DefectRepository defectRepository;
+
+    @Transactional(readOnly = true)
+    public GetAnalysisResponse getAnalysis(Long userId, Long analysisId) {
+        Analysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_001));
+
+        Room room = roomRepository.findById(analysis.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        if (analysis.getStatus() != Analysis.Status.COMPLETED) {
+            throw new CustomException(ErrorCode.ANALYSIS_004);
+        }
+
+        List<DefectItemResponse> defects = defectRepository.findByAnalysisId(analysisId)
+                .stream()
+                .map(DefectItemResponse::from)
+                .toList();
+
+        return GetAnalysisResponse.of(analysis, defects);
+    }
 
     @Transactional
     public CreateAnalysisResponse createAnalysis(Long userId, CreateAnalysisRequest request) {
@@ -36,6 +66,10 @@ public class AnalysisService {
 
         Scan outScan = scanRepository.findById(request.getOutScanId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_003));
+
+        if (!inScan.getUserId().equals(userId) || !outScan.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
 
         if (inScan.getScanType() != Scan.ScanType.IN || outScan.getScanType() != Scan.ScanType.OUT) {
             throw new CustomException(ErrorCode.ANALYSIS_003);

--- a/src/main/java/com/roomlog/analysis/service/AnalysisService.java
+++ b/src/main/java/com/roomlog/analysis/service/AnalysisService.java
@@ -1,4 +1,57 @@
 package com.roomlog.analysis.service;
 
+import com.roomlog.analysis.domain.Analysis;
+import com.roomlog.analysis.dto.CreateAnalysisRequest;
+import com.roomlog.analysis.dto.CreateAnalysisResponse;
+import com.roomlog.analysis.repository.AnalysisRepository;
+import com.roomlog.global.exception.CustomException;
+import com.roomlog.global.exception.ErrorCode;
+import com.roomlog.room.domain.Room;
+import com.roomlog.room.repository.RoomRepository;
+import com.roomlog.scan.domain.Scan;
+import com.roomlog.scan.repository.ScanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class AnalysisService {
+
+    private final AnalysisRepository analysisRepository;
+    private final RoomRepository roomRepository;
+    private final ScanRepository scanRepository;
+
+    @Transactional
+    public CreateAnalysisResponse createAnalysis(Long userId, CreateAnalysisRequest request) {
+        Room room = roomRepository.findById(request.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        Scan inScan = scanRepository.findById(request.getInScanId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_003));
+
+        Scan outScan = scanRepository.findById(request.getOutScanId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_003));
+
+        if (inScan.getScanType() != Scan.ScanType.IN || outScan.getScanType() != Scan.ScanType.OUT) {
+            throw new CustomException(ErrorCode.ANALYSIS_003);
+        }
+
+        if (inScan.getStatus() != Scan.Status.COMPLETED || outScan.getStatus() != Scan.Status.COMPLETED) {
+            throw new CustomException(ErrorCode.ANALYSIS_003);
+        }
+
+        Analysis analysis = Analysis.builder()
+                .roomId(request.getRoomId())
+                .inScanId(request.getInScanId())
+                .outScanId(request.getOutScanId())
+                .build();
+        analysisRepository.save(analysis);
+
+        return CreateAnalysisResponse.of(analysis, inScan, outScan);
+    }
 }

--- a/src/main/java/com/roomlog/analysis/service/AnalysisService.java
+++ b/src/main/java/com/roomlog/analysis/service/AnalysisService.java
@@ -68,7 +68,7 @@ public class AnalysisService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_003));
 
         if (!inScan.getUserId().equals(userId) || !outScan.getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.ROOM_002);
+            throw new CustomException(ErrorCode.COMMON_403);
         }
 
         if (inScan.getScanType() != Scan.ScanType.IN || outScan.getScanType() != Scan.ScanType.OUT) {

--- a/src/main/java/com/roomlog/auth/controller/AuthController.java
+++ b/src/main/java/com/roomlog/auth/controller/AuthController.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "1. 인증", description = "회원가입, 로그인, 토큰 재발급 API")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -23,7 +22,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "A01. 회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입합니다.")
+    @Operation(summary = "A01. 회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입합니다.", tags = "6. Auth")
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
@@ -31,14 +30,14 @@ public class AuthController {
         return ApiResponse.success(201, "회원가입에 성공했습니다.", response);
     }
 
-    @Operation(summary = "A02. 로그인", description = "이메일, 비밀번호로 로그인하고 액세스 토큰을 발급받습니다.")
+    @Operation(summary = "A02. 로그인", description = "이메일, 비밀번호로 로그인하고 액세스 토큰을 발급받습니다.", tags = "6. Auth")
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ApiResponse.success(200, "로그인에 성공했습니다.", response);
     }
 
-    @Operation(summary = "A03. 토큰 재발급", description = "리프레시 토큰으로 새로운 액세스 토큰을 발급받습니다.")
+    @Operation(summary = "A03. 토큰 재발급", description = "리프레시 토큰으로 새로운 액세스 토큰을 발급받습니다.", tags = "6. Auth")
     @PostMapping("/refresh")
     public ApiResponse<ReissueResponse> reissue(@Valid @RequestBody ReissueRequest request) {
         ReissueResponse response = authService.reissue(request);

--- a/src/main/java/com/roomlog/auth/controller/AuthController.java
+++ b/src/main/java/com/roomlog/auth/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.roomlog.auth.dto.SignupResponse;
 import com.roomlog.auth.service.AuthService;
 import com.roomlog.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/roomlog/defect/controller/DefectController.java
+++ b/src/main/java/com/roomlog/defect/controller/DefectController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "6. 하자", description = "하자 목록 조회, 상세 조회 API")
 @RestController
 @RequestMapping("/defects")
 @RequiredArgsConstructor

--- a/src/main/java/com/roomlog/defect/controller/DefectController.java
+++ b/src/main/java/com/roomlog/defect/controller/DefectController.java
@@ -1,11 +1,31 @@
 package com.roomlog.defect.controller;
 
+import com.roomlog.defect.dto.GetDefectDetailResponse;
+import com.roomlog.defect.service.DefectService;
+import com.roomlog.global.response.ApiResponse;
+import com.roomlog.global.security.LoginUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "6. 하자", description = "하자 목록 조회, 상세 조회 API")
 @RestController
 @RequestMapping("/defects")
+@RequiredArgsConstructor
 public class DefectController {
+
+    private final DefectService defectService;
+
+    @Operation(summary = "V05. 하자 상세 조회", description = "하자 ID로 하자의 상세 정보를 조회합니다.", tags = "3. Viewer")
+    @GetMapping("/{defectId}")
+    public ApiResponse<GetDefectDetailResponse> getDefectDetail(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "조회할 하자 ID", example = "101") @PathVariable Long defectId) {
+
+        GetDefectDetailResponse response = defectService.getDefectDetail(defectId);
+        return ApiResponse.success(200, "하자 상세 조회에 성공했습니다.", response);
+    }
 }

--- a/src/main/java/com/roomlog/defect/controller/DefectController.java
+++ b/src/main/java/com/roomlog/defect/controller/DefectController.java
@@ -6,7 +6,6 @@ import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/roomlog/defect/domain/DefectUnitPrice.java
+++ b/src/main/java/com/roomlog/defect/domain/DefectUnitPrice.java
@@ -1,0 +1,30 @@
+package com.roomlog.defect.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "defect_unit_price")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DefectUnitPrice {
+
+    @Id
+    @Column(name = "defect_type", length = 20)
+    private String defectType;
+
+    @Column(name = "unit_price", nullable = false)
+    private Integer unitPrice;
+
+    @Builder
+    public DefectUnitPrice(String defectType, Integer unitPrice) {
+        this.defectType = defectType;
+        this.unitPrice = unitPrice;
+    }
+}

--- a/src/main/java/com/roomlog/defect/domain/SeverityMultiplier.java
+++ b/src/main/java/com/roomlog/defect/domain/SeverityMultiplier.java
@@ -1,0 +1,15 @@
+package com.roomlog.defect.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeverityMultiplier {
+
+    LOW(1.0),
+    MEDIUM(1.5),
+    HIGH(2.0);
+
+    private final double multiplier;
+}

--- a/src/main/java/com/roomlog/defect/dto/DefectItemResponse.java
+++ b/src/main/java/com/roomlog/defect/dto/DefectItemResponse.java
@@ -1,4 +1,53 @@
 package com.roomlog.defect.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.defect.domain.Defect;
+import lombok.Getter;
+
+@Getter
 public class DefectItemResponse {
+
+    @JsonProperty("defect_id")
+    private final Long defectId;
+
+    private final String type;
+
+    private final String location;
+
+    private final String severity;
+
+    private final Float area;
+
+    @JsonProperty("estimated_cost")
+    private final Integer estimatedCost;
+
+    private final Float x;
+
+    private final Float y;
+
+    private final Float z;
+
+    @JsonProperty("before_image_url")
+    private final String beforeImageUrl;
+
+    @JsonProperty("after_image_url")
+    private final String afterImageUrl;
+
+    private DefectItemResponse(Defect defect) {
+        this.defectId = defect.getId();
+        this.type = defect.getType();
+        this.location = defect.getLocation();
+        this.severity = defect.getSeverity();
+        this.area = defect.getArea();
+        this.estimatedCost = defect.getEstimatedCost();
+        this.x = defect.getX();
+        this.y = defect.getY();
+        this.z = defect.getZ();
+        this.beforeImageUrl = defect.getBeforeImageUrl();
+        this.afterImageUrl = defect.getAfterImageUrl();
+    }
+
+    public static DefectItemResponse from(Defect defect) {
+        return new DefectItemResponse(defect);
+    }
 }

--- a/src/main/java/com/roomlog/defect/dto/GetDefectDetailResponse.java
+++ b/src/main/java/com/roomlog/defect/dto/GetDefectDetailResponse.java
@@ -1,4 +1,60 @@
 package com.roomlog.defect.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.defect.domain.Defect;
+import lombok.Getter;
+
+@Getter
 public class GetDefectDetailResponse {
+
+    @JsonProperty("defect_id")
+    private final Long defectId;
+
+    @JsonProperty("analysis_id")
+    private final Long analysisId;
+
+    private final String type;
+
+    private final String location;
+
+    private final Float area;
+
+    @JsonProperty("estimated_cost")
+    private final Integer estimatedCost;
+
+    private final String severity;
+
+    private final Float x;
+
+    private final Float y;
+
+    private final Float z;
+
+    private final String description;
+
+    @JsonProperty("before_image_url")
+    private final String beforeImageUrl;
+
+    @JsonProperty("after_image_url")
+    private final String afterImageUrl;
+
+    private GetDefectDetailResponse(Defect defect) {
+        this.defectId = defect.getId();
+        this.analysisId = defect.getAnalysisId();
+        this.type = defect.getType();
+        this.location = defect.getLocation();
+        this.area = defect.getArea();
+        this.estimatedCost = defect.getEstimatedCost();
+        this.severity = defect.getSeverity();
+        this.x = defect.getX();
+        this.y = defect.getY();
+        this.z = defect.getZ();
+        this.description = defect.getDescription();
+        this.beforeImageUrl = defect.getBeforeImageUrl();
+        this.afterImageUrl = defect.getAfterImageUrl();
+    }
+
+    public static GetDefectDetailResponse from(Defect defect) {
+        return new GetDefectDetailResponse(defect);
+    }
 }

--- a/src/main/java/com/roomlog/defect/dto/GetDefectEntryResponse.java
+++ b/src/main/java/com/roomlog/defect/dto/GetDefectEntryResponse.java
@@ -1,0 +1,40 @@
+package com.roomlog.defect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.room.domain.Room;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class GetDefectEntryResponse {
+
+    @JsonProperty("room_id")
+    private final Long roomId;
+
+    private final String name;
+
+    private final String address;
+
+    @JsonProperty("thumbnail_url")
+    private final String thumbnailUrl;
+
+    @JsonProperty("move_in_date")
+    private final LocalDate moveInDate;
+
+    @JsonProperty("move_out_date")
+    private final LocalDate moveOutDate;
+
+    private GetDefectEntryResponse(Room room) {
+        this.roomId = room.getId();
+        this.name = room.getName();
+        this.address = room.getAddress();
+        this.thumbnailUrl = room.getThumbnailUrl();
+        this.moveInDate = room.getMoveInDate();
+        this.moveOutDate = room.getMoveOutDate();
+    }
+
+    public static GetDefectEntryResponse from(Room room) {
+        return new GetDefectEntryResponse(room);
+    }
+}

--- a/src/main/java/com/roomlog/defect/repository/DefectUnitPriceRepository.java
+++ b/src/main/java/com/roomlog/defect/repository/DefectUnitPriceRepository.java
@@ -1,0 +1,7 @@
+package com.roomlog.defect.repository;
+
+import com.roomlog.defect.domain.DefectUnitPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DefectUnitPriceRepository extends JpaRepository<DefectUnitPrice, String> {
+}

--- a/src/main/java/com/roomlog/defect/service/DefectService.java
+++ b/src/main/java/com/roomlog/defect/service/DefectService.java
@@ -1,4 +1,29 @@
 package com.roomlog.defect.service;
 
+import com.roomlog.defect.dto.GetDefectEntryResponse;
+import com.roomlog.global.exception.CustomException;
+import com.roomlog.global.exception.ErrorCode;
+import com.roomlog.room.domain.Room;
+import com.roomlog.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class DefectService {
+
+    private final RoomRepository roomRepository;
+
+    @Transactional(readOnly = true)
+    public GetDefectEntryResponse getDefectEntry(Long userId, Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        return GetDefectEntryResponse.from(room);
+    }
 }

--- a/src/main/java/com/roomlog/defect/service/DefectService.java
+++ b/src/main/java/com/roomlog/defect/service/DefectService.java
@@ -1,6 +1,9 @@
 package com.roomlog.defect.service;
 
+import com.roomlog.defect.domain.Defect;
+import com.roomlog.defect.dto.GetDefectDetailResponse;
 import com.roomlog.defect.dto.GetDefectEntryResponse;
+import com.roomlog.defect.repository.DefectRepository;
 import com.roomlog.global.exception.CustomException;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.room.domain.Room;
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DefectService {
 
     private final RoomRepository roomRepository;
+    private final DefectRepository defectRepository;
 
     @Transactional(readOnly = true)
     public GetDefectEntryResponse getDefectEntry(Long userId, Long roomId) {
@@ -25,5 +29,13 @@ public class DefectService {
         }
 
         return GetDefectEntryResponse.from(room);
+    }
+
+    @Transactional(readOnly = true)
+    public GetDefectDetailResponse getDefectDetail(Long defectId) {
+        Defect defect = defectRepository.findById(defectId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DEFECT_001));
+
+        return GetDefectDetailResponse.from(defect);
     }
 }

--- a/src/main/java/com/roomlog/estimate/controller/EstimateController.java
+++ b/src/main/java/com/roomlog/estimate/controller/EstimateController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "7. 견적", description = "견적 요청, 목록 조회, 상세 조회 API")
 @RestController
 @RequestMapping("/estimates")
 public class EstimateController {

--- a/src/main/java/com/roomlog/estimate/controller/EstimateController.java
+++ b/src/main/java/com/roomlog/estimate/controller/EstimateController.java
@@ -1,6 +1,5 @@
 package com.roomlog.estimate.controller;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/roomlog/global/config/DefectUnitPriceInitializer.java
+++ b/src/main/java/com/roomlog/global/config/DefectUnitPriceInitializer.java
@@ -1,0 +1,30 @@
+package com.roomlog.global.config;
+
+import com.roomlog.defect.domain.DefectUnitPrice;
+import com.roomlog.defect.repository.DefectUnitPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DefectUnitPriceInitializer implements ApplicationRunner {
+
+    private final DefectUnitPriceRepository defectUnitPriceRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (defectUnitPriceRepository.count() > 0) return;
+
+        defectUnitPriceRepository.saveAll(List.of(
+                DefectUnitPrice.builder().defectType("SCRATCH").unitPrice(25000).build(),
+                DefectUnitPrice.builder().defectType("CRACK").unitPrice(75000).build(),
+                DefectUnitPrice.builder().defectType("PEELING").unitPrice(45000).build(),
+                DefectUnitPrice.builder().defectType("STAIN").unitPrice(20000).build(),
+                DefectUnitPrice.builder().defectType("BREAKAGE").unitPrice(120000).build()
+        ));
+    }
+}

--- a/src/main/java/com/roomlog/global/config/SwaggerConfig.java
+++ b/src/main/java/com/roomlog/global/config/SwaggerConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.tags.Tag;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -26,6 +29,17 @@ public class SwaggerConfig {
                                 .name(securitySchemeName)
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
-                                .bearerFormat("JWT")));
+                                .bearerFormat("JWT")))
+                .tags(List.of(
+                        new Tag().name("1. 인증").description("회원가입, 로그인, 토큰 재발급 API"),
+                        new Tag().name("2. 방").description("방 목록 조회, 상세 조회, 수정, 삭제 API"),
+                        new Tag().name("3. Viewer").description("3D 뷰어 조회, 스캔 목록, 하자 상세 조회 API"),
+                        new Tag().name("4. 스캔").description("3D 스캔 업로드, 상태 조회, 미리보기 API"),
+                        new Tag().name("5. 분석").description("하자 분석 생성, 결과 조회 API"),
+                        new Tag().name("6. 하자").description("하자 목록 조회, 상세 조회 API"),
+                        new Tag().name("7. 견적").description("견적 요청, 목록 조회, 상세 조회 API"),
+                        new Tag().name("8. 수리").description("수리 내역 조회, 수리 완료 등록 API"),
+                        new Tag().name("9. 마이페이지").description("프로필 조회, 내 정보 수정, 회원 탈퇴 API")
+                ));
     }
 }

--- a/src/main/java/com/roomlog/global/config/SwaggerConfig.java
+++ b/src/main/java/com/roomlog/global/config/SwaggerConfig.java
@@ -31,15 +31,13 @@ public class SwaggerConfig {
                                 .scheme("bearer")
                                 .bearerFormat("JWT")))
                 .tags(List.of(
-                        new Tag().name("1. 인증").description("회원가입, 로그인, 토큰 재발급 API"),
-                        new Tag().name("2. 방").description("방 목록 조회, 상세 조회, 수정, 삭제 API"),
-                        new Tag().name("3. Viewer").description("3D 뷰어 조회, 스캔 목록, 하자 상세 조회 API"),
-                        new Tag().name("4. 스캔").description("3D 스캔 업로드, 상태 조회, 미리보기 API"),
-                        new Tag().name("5. 분석").description("하자 분석 생성, 결과 조회 API"),
-                        new Tag().name("6. 하자").description("하자 목록 조회, 상세 조회 API"),
-                        new Tag().name("7. 견적").description("견적 요청, 목록 조회, 상세 조회 API"),
-                        new Tag().name("8. 수리").description("수리 내역 조회, 수리 완료 등록 API"),
-                        new Tag().name("9. 마이페이지").description("프로필 조회, 내 정보 수정, 회원 탈퇴 API")
+                        new Tag().name("1. Home").description("메인 대시보드, 방 목록/상세/수정/삭제 API"),
+                        new Tag().name("2. Scan").description("3D 스캔 업로드, 방 생성, 상태 조회, 미리보기 API"),
+                        new Tag().name("3. Viewer").description("3D 뷰어, 비교 시점 선택, 분석 생성/조회, 하자 상세 조회 API"),
+                        new Tag().name("4. Defect").description("방 하자 목록 조회 API"),
+                        new Tag().name("5. Repair").description("업체 조회, 견적 요청/조회, 수리 내역 조회, 수리 완료 등록 API"),
+                        new Tag().name("6. Auth").description("회원가입, 로그인, 토큰 재발급 API"),
+                        new Tag().name("7. MyPage").description("프로필 조회, 내 정보 수정, 회원 탈퇴 API")
                 ));
     }
 }

--- a/src/main/java/com/roomlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/roomlog/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 
     // Analysis
     ANALYSIS_001(HttpStatus.NOT_FOUND, "ANALYSIS_001", "분석 결과가 존재하지 않습니다."),
+    ANALYSIS_002(HttpStatus.BAD_REQUEST, "ANALYSIS_002", "이미 처리된 분석입니다."),
     ANALYSIS_003(HttpStatus.BAD_REQUEST, "ANALYSIS_003", "선택한 스캔 조합이 올바르지 않거나 비교 가능한 스캔이 부족합니다."),
     ANALYSIS_004(HttpStatus.BAD_REQUEST, "ANALYSIS_004", "분석이 아직 완료되지 않았습니다."),
 

--- a/src/main/java/com/roomlog/global/security/ApiKeyFilter.java
+++ b/src/main/java/com/roomlog/global/security/ApiKeyFilter.java
@@ -1,0 +1,46 @@
+package com.roomlog.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roomlog.global.exception.ErrorCode;
+import com.roomlog.global.response.ApiResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    private static final String API_KEY_HEADER = "X-Api-Key";
+    private static final String AI_RESULT_PATH = "/analyses/*/result";
+
+    private final String apiKey;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !new AntPathMatcher().match(AI_RESULT_PATH, request.getServletPath());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String key = request.getHeader(API_KEY_HEADER);
+
+        if (!apiKey.equals(key)) {
+            response.setStatus(ErrorCode.COMMON_401.getHttpStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            objectMapper.writeValue(response.getWriter(), ApiResponse.failure(ErrorCode.COMMON_401));
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/roomlog/global/security/SecurityConfig.java
+++ b/src/main/java/com/roomlog/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -22,6 +23,9 @@ public class SecurityConfig {
     private final AuthToken authToken;
     private final ObjectMapper objectMapper;
 
+    @Value("${ai.api-key}")
+    private String aiApiKey;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -30,6 +34,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/analyses/*/result").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex
@@ -40,6 +45,8 @@ public class SecurityConfig {
                             objectMapper.writeValue(response.getWriter(), ApiResponse.failure(ErrorCode.COMMON_401));
                         })
                 )
+                .addFilterBefore(new ApiKeyFilter(aiApiKey, objectMapper),
+                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtAuthenticationFilter(authToken, objectMapper),
                         UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/roomlog/repair/controller/RepairController.java
+++ b/src/main/java/com/roomlog/repair/controller/RepairController.java
@@ -1,6 +1,5 @@
 package com.roomlog.repair.controller;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/roomlog/repair/controller/RepairController.java
+++ b/src/main/java/com/roomlog/repair/controller/RepairController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "8. 수리", description = "수리 내역 조회, 수리 완료 등록 API")
 @RestController
 @RequestMapping("/repairs")
 public class RepairController {

--- a/src/main/java/com/roomlog/room/controller/RoomController.java
+++ b/src/main/java/com/roomlog/room/controller/RoomController.java
@@ -2,8 +2,6 @@ package com.roomlog.room.controller;
 
 import com.roomlog.defect.dto.GetDefectEntryResponse;
 import com.roomlog.defect.service.DefectService;
-import com.roomlog.scan.dto.GetRoomScansResponse;
-import com.roomlog.scan.service.ScanService;
 import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import com.roomlog.room.dto.CreateRoomRequest;
@@ -15,6 +13,8 @@ import com.roomlog.room.dto.SetMainRoomResponse;
 import com.roomlog.room.dto.UpdateRoomRequest;
 import com.roomlog.room.dto.UpdateRoomResponse;
 import com.roomlog.room.service.RoomService;
+import com.roomlog.scan.dto.GetRoomScansResponse;
+import com.roomlog.scan.service.ScanService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "2. 방", description = "방 목록 조회, 상세 조회, 수정, 삭제 API")
 @RestController
 @RequestMapping("/rooms")
 @RequiredArgsConstructor
@@ -33,7 +32,7 @@ public class RoomController {
     private final DefectService defectService;
     private final ScanService scanService;
 
-    @Operation(summary = "S05. 방 생성", description = "scan_id로 업로드된 스캔과 함께 새로운 방을 생성합니다. 생성된 방은 자동으로 대표 방으로 설정됩니다.", tags = "4. 스캔")
+    @Operation(summary = "S05. 방 생성", description = "scan_id로 업로드된 스캔과 함께 새로운 방을 생성합니다. 생성된 방은 자동으로 대표 방으로 설정됩니다.", tags = "2. Scan")
     @PostMapping
     public ApiResponse<CreateRoomResponse> createRoom(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -42,14 +41,14 @@ public class RoomController {
         return ApiResponse.success(201, "방 생성에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H01. 방 목록 조회", description = "로그인한 사용자의 대표 방 요약 정보와 전체 방 리스트를 조회합니다.")
+    @Operation(summary = "H01. 메인 대시보드 조회", description = "로그인한 사용자의 대표 방 요약 정보와 전체 방 리스트를 조회합니다.", tags = "1. Home")
     @GetMapping
     public ApiResponse<GetRoomsResponse> getRooms(@AuthenticationPrincipal LoginUser loginUser) {
         GetRoomsResponse response = roomService.getRooms(loginUser.userId());
         return ApiResponse.success(200, "방 목록 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H03. 방 상세 조회", description = "방 ID로 방의 상세 정보와 최신 스캔 정보를 조회합니다.")
+    @Operation(summary = "H03. 방 상세 조회", description = "방 ID로 방의 상세 정보와 최신 스캔 정보를 조회합니다.", tags = "1. Home")
     @GetMapping("/{roomId}")
     public ApiResponse<GetRoomDetailResponse> getRoomDetail(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -58,7 +57,7 @@ public class RoomController {
         return ApiResponse.success(200, "방 상세 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H04. 방 정보 수정", description = "방 이름, 주소, 입주일, 퇴거일을 수정합니다.")
+    @Operation(summary = "H04. 방 정보 수정", description = "방 이름, 주소, 입주일, 퇴거일을 수정합니다.", tags = "1. Home")
     @PatchMapping("/{roomId}")
     public ApiResponse<UpdateRoomResponse> updateRoom(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -68,7 +67,7 @@ public class RoomController {
         return ApiResponse.success(200, "방 정보 수정에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H05. 대표 방 설정", description = "선택한 방을 대표 방으로 설정합니다.")
+    @Operation(summary = "H05. 대표 방 설정", description = "선택한 방을 대표 방으로 설정합니다.", tags = "1. Home")
     @PatchMapping("/{roomId}/main")
     public ApiResponse<SetMainRoomResponse> setMainRoom(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -77,7 +76,7 @@ public class RoomController {
         return ApiResponse.success(200, "대표 방 설정에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H06. 방 삭제", description = "방을 삭제합니다. 연결된 스캔, 분석, 하자, 견적, 수리 내역도 함께 soft delete됩니다.")
+    @Operation(summary = "H06. 방 삭제", description = "방을 삭제합니다. 연결된 스캔, 분석, 하자, 견적, 수리 내역도 함께 soft delete됩니다.", tags = "1. Home")
     @DeleteMapping("/{roomId}")
     public ApiResponse<DeleteRoomResponse> deleteRoom(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -87,7 +86,7 @@ public class RoomController {
     }
 
     @Operation(summary = "V02. 방의 스캔 목록 조회", description = "방 ID로 해당 방에 연결된 전체 스캔 목록(IN/OUT)을 조회합니다. 입주/퇴거 비교 대상 선택 시 사용합니다.", tags = "3. Viewer")
-    @GetMapping("/{roomId}/scans")
+    @GetMapping("/{roomId}/scan")
     public ApiResponse<GetRoomScansResponse> getRoomScans(
             @AuthenticationPrincipal LoginUser loginUser,
             @Parameter(description = "조회할 방 ID", example = "1") @PathVariable Long roomId) {
@@ -95,7 +94,7 @@ public class RoomController {
         return ApiResponse.success(200, "방의 스캔 목록 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "D01. 하자 관리 진입 정보 조회", description = "선택한 방의 기본 정보를 조회합니다. 하자 관리 화면 진입 시 사용합니다.", tags = "6. 하자")
+    @Operation(summary = "D01. 방 하자 목록 조회", description = "선택한 방의 기본 정보를 조회합니다. 하자 관리 화면 진입 시 사용합니다.", tags = "4. Defect")
     @GetMapping("/{roomId}/defects")
     public ApiResponse<GetDefectEntryResponse> getDefectEntry(
             @AuthenticationPrincipal LoginUser loginUser,

--- a/src/main/java/com/roomlog/room/controller/RoomController.java
+++ b/src/main/java/com/roomlog/room/controller/RoomController.java
@@ -1,5 +1,7 @@
 package com.roomlog.room.controller;
 
+import com.roomlog.defect.dto.GetDefectEntryResponse;
+import com.roomlog.defect.service.DefectService;
 import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import com.roomlog.room.dto.CreateRoomRequest;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class RoomController {
 
     private final RoomService roomService;
+    private final DefectService defectService;
 
     @Operation(summary = "S05. 방 생성", description = "방 이름, 주소, 입주/퇴거일과 scan_id를 입력하면 업로드된 스캔과 함께 새로운 방을 생성하고 해당 스캔을 방에 연결합니다. 각 방은 하나의 스캔만 가집니다.", tags = "4. 스캔")
     @PostMapping
@@ -77,5 +80,14 @@ public class RoomController {
             @PathVariable Long roomId) {
         DeleteRoomResponse response = roomService.deleteRoom(loginUser.userId(), roomId);
         return ApiResponse.success(200, "방 삭제에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "D01. 하자 관리 진입 정보 조회", description = "선택한 방의 기본 정보를 조회합니다. 하자 관리 화면 진입 시 사용합니다.", tags = "6. 하자")
+    @GetMapping("/{roomId}/defects")
+    public ApiResponse<GetDefectEntryResponse> getDefectEntry(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @PathVariable Long roomId) {
+        GetDefectEntryResponse response = defectService.getDefectEntry(loginUser.userId(), roomId);
+        return ApiResponse.success(200, "하자 관리 진입 정보 조회에 성공했습니다.", response);
     }
 }

--- a/src/main/java/com/roomlog/room/controller/RoomController.java
+++ b/src/main/java/com/roomlog/room/controller/RoomController.java
@@ -16,6 +16,7 @@ import com.roomlog.room.dto.UpdateRoomRequest;
 import com.roomlog.room.dto.UpdateRoomResponse;
 import com.roomlog.room.service.RoomService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class RoomController {
     private final DefectService defectService;
     private final ScanService scanService;
 
-    @Operation(summary = "S05. 방 생성", description = "방 이름, 주소, 입주/퇴거일과 scan_id를 입력하면 업로드된 스캔과 함께 새로운 방을 생성하고 해당 스캔을 방에 연결합니다. 각 방은 하나의 스캔만 가집니다.", tags = "4. 스캔")
+    @Operation(summary = "S05. 방 생성", description = "scan_id로 업로드된 스캔과 함께 새로운 방을 생성합니다. 생성된 방은 자동으로 대표 방으로 설정됩니다.", tags = "4. 스캔")
     @PostMapping
     public ApiResponse<CreateRoomResponse> createRoom(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -41,7 +42,7 @@ public class RoomController {
         return ApiResponse.success(201, "방 생성에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H01. 방 목록 조회", description = "로그인한 사용자의 대표 방(main room) 요약 정보와 전체 room 리스트를 조회합니다. 대표 방은 최초 방 생성 시 가장 마지막에 생성된 방으로 자동 설정되며, 사용자가 직접 변경한 이후에는 해당 설정이 우선 적용됩니다.")
+    @Operation(summary = "H01. 방 목록 조회", description = "로그인한 사용자의 대표 방 요약 정보와 전체 방 리스트를 조회합니다.")
     @GetMapping
     public ApiResponse<GetRoomsResponse> getRooms(@AuthenticationPrincipal LoginUser loginUser) {
         GetRoomsResponse response = roomService.getRooms(loginUser.userId());
@@ -52,7 +53,7 @@ public class RoomController {
     @GetMapping("/{roomId}")
     public ApiResponse<GetRoomDetailResponse> getRoomDetail(
             @AuthenticationPrincipal LoginUser loginUser,
-            @PathVariable Long roomId) {
+            @Parameter(description = "조회할 방 ID", example = "1") @PathVariable Long roomId) {
         GetRoomDetailResponse response = roomService.getRoomDetail(loginUser.userId(), roomId);
         return ApiResponse.success(200, "방 상세 조회에 성공했습니다.", response);
     }
@@ -61,26 +62,26 @@ public class RoomController {
     @PatchMapping("/{roomId}")
     public ApiResponse<UpdateRoomResponse> updateRoom(
             @AuthenticationPrincipal LoginUser loginUser,
-            @PathVariable Long roomId,
+            @Parameter(description = "수정할 방 ID", example = "1") @PathVariable Long roomId,
             @Valid @RequestBody UpdateRoomRequest request) {
         UpdateRoomResponse response = roomService.updateRoom(loginUser.userId(), roomId, request);
         return ApiResponse.success(200, "방 정보 수정에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H05. 대표 방 설정", description = "선택한 room을 사용자의 대표 방(main room)으로 설정하고 User.main_room_id를 갱신합니다.")
+    @Operation(summary = "H05. 대표 방 설정", description = "선택한 방을 대표 방으로 설정합니다.")
     @PatchMapping("/{roomId}/main")
     public ApiResponse<SetMainRoomResponse> setMainRoom(
             @AuthenticationPrincipal LoginUser loginUser,
-            @PathVariable Long roomId) {
+            @Parameter(description = "대표 방으로 설정할 방 ID", example = "1") @PathVariable Long roomId) {
         SetMainRoomResponse response = roomService.setMainRoom(loginUser.userId(), roomId);
         return ApiResponse.success(200, "대표 방 설정에 성공했습니다.", response);
     }
 
-    @Operation(summary = "H06. 방 삭제", description = "방을 삭제합니다. 연결된 스캔, 분석, 하자, 견적, 수리 내역도 함께 삭제됩니다. 대표 방 삭제 시 가장 최근 스캔된 방으로 자동 재설정됩니다.")
+    @Operation(summary = "H06. 방 삭제", description = "방을 삭제합니다. 연결된 스캔, 분석, 하자, 견적, 수리 내역도 함께 soft delete됩니다.")
     @DeleteMapping("/{roomId}")
     public ApiResponse<DeleteRoomResponse> deleteRoom(
             @AuthenticationPrincipal LoginUser loginUser,
-            @PathVariable Long roomId) {
+            @Parameter(description = "삭제할 방 ID", example = "1") @PathVariable Long roomId) {
         DeleteRoomResponse response = roomService.deleteRoom(loginUser.userId(), roomId);
         return ApiResponse.success(200, "방 삭제에 성공했습니다.", response);
     }
@@ -89,7 +90,7 @@ public class RoomController {
     @GetMapping("/{roomId}/scans")
     public ApiResponse<GetRoomScansResponse> getRoomScans(
             @AuthenticationPrincipal LoginUser loginUser,
-            @PathVariable Long roomId) {
+            @Parameter(description = "조회할 방 ID", example = "1") @PathVariable Long roomId) {
         GetRoomScansResponse response = scanService.getRoomScans(loginUser.userId(), roomId);
         return ApiResponse.success(200, "방의 스캔 목록 조회에 성공했습니다.", response);
     }
@@ -98,7 +99,7 @@ public class RoomController {
     @GetMapping("/{roomId}/defects")
     public ApiResponse<GetDefectEntryResponse> getDefectEntry(
             @AuthenticationPrincipal LoginUser loginUser,
-            @PathVariable Long roomId) {
+            @Parameter(description = "조회할 방 ID", example = "1") @PathVariable Long roomId) {
         GetDefectEntryResponse response = defectService.getDefectEntry(loginUser.userId(), roomId);
         return ApiResponse.success(200, "하자 관리 진입 정보 조회에 성공했습니다.", response);
     }

--- a/src/main/java/com/roomlog/room/controller/RoomController.java
+++ b/src/main/java/com/roomlog/room/controller/RoomController.java
@@ -2,6 +2,8 @@ package com.roomlog.room.controller;
 
 import com.roomlog.defect.dto.GetDefectEntryResponse;
 import com.roomlog.defect.service.DefectService;
+import com.roomlog.scan.dto.GetRoomScansResponse;
+import com.roomlog.scan.service.ScanService;
 import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import com.roomlog.room.dto.CreateRoomRequest;
@@ -28,6 +30,7 @@ public class RoomController {
 
     private final RoomService roomService;
     private final DefectService defectService;
+    private final ScanService scanService;
 
     @Operation(summary = "S05. 방 생성", description = "방 이름, 주소, 입주/퇴거일과 scan_id를 입력하면 업로드된 스캔과 함께 새로운 방을 생성하고 해당 스캔을 방에 연결합니다. 각 방은 하나의 스캔만 가집니다.", tags = "4. 스캔")
     @PostMapping
@@ -80,6 +83,15 @@ public class RoomController {
             @PathVariable Long roomId) {
         DeleteRoomResponse response = roomService.deleteRoom(loginUser.userId(), roomId);
         return ApiResponse.success(200, "방 삭제에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "V02. 방의 스캔 목록 조회", description = "방 ID로 해당 방에 연결된 전체 스캔 목록(IN/OUT)을 조회합니다. 입주/퇴거 비교 대상 선택 시 사용합니다.", tags = "3. Viewer")
+    @GetMapping("/{roomId}/scans")
+    public ApiResponse<GetRoomScansResponse> getRoomScans(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @PathVariable Long roomId) {
+        GetRoomScansResponse response = scanService.getRoomScans(loginUser.userId(), roomId);
+        return ApiResponse.success(200, "방의 스캔 목록 조회에 성공했습니다.", response);
     }
 
     @Operation(summary = "D01. 하자 관리 진입 정보 조회", description = "선택한 방의 기본 정보를 조회합니다. 하자 관리 화면 진입 시 사용합니다.", tags = "6. 하자")

--- a/src/main/java/com/roomlog/room/controller/RoomController.java
+++ b/src/main/java/com/roomlog/room/controller/RoomController.java
@@ -17,7 +17,6 @@ import com.roomlog.scan.dto.GetRoomScansResponse;
 import com.roomlog.scan.service.ScanService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/roomlog/room/service/RoomService.java
+++ b/src/main/java/com/roomlog/room/service/RoomService.java
@@ -50,6 +50,10 @@ public class RoomService {
         Scan scan = scanRepository.findById(request.getScanId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SCAN_001));
 
+        if (!scan.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMON_403);
+        }
+
         if (scan.getStatus() != Scan.Status.COMPLETED) {
             throw new CustomException(ErrorCode.SCAN_004);
         }
@@ -93,7 +97,7 @@ public class RoomService {
                 .toList();
 
         Room mainRoom = user.getMainRoomId() != null
-                ? roomRepository.findById(user.getMainRoomId()).orElse(null)
+                ? roomRepository.findByIdAndUserId(user.getMainRoomId(), userId).orElse(null)
                 : null;
 
         return GetRoomsResponse.of(mainRoom, roomItems);

--- a/src/main/java/com/roomlog/room/service/RoomService.java
+++ b/src/main/java/com/roomlog/room/service/RoomService.java
@@ -86,9 +86,7 @@ public class RoomService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMON_401));
 
-        List<Room> rooms = roomRepository.findByUserId(userId);
-
-        List<RoomListItemResponse> roomItems = rooms.stream()
+        List<RoomListItemResponse> roomItems = roomRepository.findByUserId(userId).stream()
                 .map(room -> {
                     Scan latestScan = scanRepository.findFirstByRoomIdOrderByCreatedAtDesc(room.getId())
                             .orElse(null);

--- a/src/main/java/com/roomlog/scan/controller/ScanController.java
+++ b/src/main/java/com/roomlog/scan/controller/ScanController.java
@@ -55,6 +55,26 @@ public class ScanController {
     }
 
     @Operation(
+            summary = "V01. 3D Viewer",
+            description = """
+                    스캔 ID로 .ply 기반 3D 파일 경로를 조회합니다.
+
+                    - 스캔 상태가 COMPLETED인 경우에만 조회 가능합니다.
+                    - 상태가 COMPLETED가 아닌 경우 400(SCAN_004) 에러가 반환됩니다.
+                    - 존재하지 않는 scanId 요청 시 404(SCAN_001) 에러가 반환됩니다.
+                    """,
+            tags = "3. Viewer"
+    )
+    @GetMapping("/{scanId}/viewer")
+    public ApiResponse<GetScanResponse> getScanViewer(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "조회할 스캔 ID", example = "12") @PathVariable Long scanId) {
+
+        GetScanResponse response = scanService.getScanPreview(loginUser.userId(), scanId);
+        return ApiResponse.success(200, "3D 스캔 결과 조회에 성공했습니다.", response);
+    }
+
+    @Operation(
             summary = "S06. 스캔 상태 조회",
             description = "스캔 ID로 현재 스캔의 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다."
     )

--- a/src/main/java/com/roomlog/scan/controller/ScanController.java
+++ b/src/main/java/com/roomlog/scan/controller/ScanController.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "4. 스캔", description = "3D 스캔 업로드, 상태 조회, 미리보기 API")
 @RestController
 @RequestMapping("/scans")
 @RequiredArgsConstructor
@@ -24,7 +23,7 @@ public class ScanController {
 
     private final ScanService scanService;
 
-    @Operation(summary = "S04. 스캔 업로드", description = "LiDAR 스캔 결과 파일(.ply)을 서버에 업로드합니다. 업로드 직후 상태는 SCANNING이며, 처리 완료 시 COMPLETED로 변경됩니다.")
+    @Operation(summary = "S04. 스캔 업로드", description = "LiDAR 스캔 결과 파일(.ply)을 서버에 업로드합니다. 업로드 직후 상태는 SCANNING이며, 처리 완료 시 COMPLETED로 변경됩니다.", tags = "2. Scan")
     @PostMapping(consumes = "multipart/form-data")
     public ApiResponse<CreateScanResponse> uploadScan(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -36,7 +35,7 @@ public class ScanController {
         return ApiResponse.success(201, "스캔 업로드에 성공했습니다.", response);
     }
 
-    @Operation(summary = "S07. 스캔 미리보기", description = "스캔 ID로 3D 파일 경로와 메타데이터를 조회합니다. COMPLETED 상태의 스캔만 조회할 수 있습니다.")
+    @Operation(summary = "S07. 스캔 미리보기", description = "스캔 ID로 3D 파일 경로와 메타데이터를 조회합니다. COMPLETED 상태의 스캔만 조회할 수 있습니다.", tags = "2. Scan")
     @GetMapping("/{scanId}/preview")
     public ApiResponse<GetScanResponse> getScanPreview(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -56,7 +55,7 @@ public class ScanController {
         return ApiResponse.success(200, "3D 스캔 결과 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "S06. 스캔 상태 조회", description = "스캔 ID로 현재 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다.")
+    @Operation(summary = "S06. 스캔 상태 조회", description = "스캔 ID로 현재 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다.", tags = "2. Scan")
     @GetMapping("/{scanId}/status")
     public ApiResponse<GetScanStatusResponse> getScanStatus(
             @AuthenticationPrincipal LoginUser loginUser,

--- a/src/main/java/com/roomlog/scan/controller/ScanController.java
+++ b/src/main/java/com/roomlog/scan/controller/ScanController.java
@@ -31,7 +31,7 @@ public class ScanController {
             @RequestPart("file") MultipartFile file,
             @RequestParam("scan_type") Scan.ScanType scanType) {
 
-        CreateScanResponse response = scanService.uploadScan(file, new CreateScanRequest(scanType));
+        CreateScanResponse response = scanService.uploadScan(loginUser.userId(), file, new CreateScanRequest(scanType));
         return ApiResponse.success(201, "스캔 업로드에 성공했습니다.", response);
     }
 

--- a/src/main/java/com/roomlog/scan/controller/ScanController.java
+++ b/src/main/java/com/roomlog/scan/controller/ScanController.java
@@ -35,6 +35,16 @@ public class ScanController {
         return ApiResponse.success(201, "스캔 업로드에 성공했습니다.", response);
     }
 
+    @Operation(summary = "S06. 스캔 상태 조회", description = "스캔 ID로 현재 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다.", tags = "2. Scan")
+    @GetMapping("/{scanId}/status")
+    public ApiResponse<GetScanStatusResponse> getScanStatus(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "조회할 스캔 ID", example = "12") @PathVariable Long scanId) {
+
+        GetScanStatusResponse response = scanService.getScanStatus(loginUser.userId(), scanId);
+        return ApiResponse.success(200, "스캔 상태 조회에 성공했습니다.", response);
+    }
+
     @Operation(summary = "S07. 스캔 미리보기", description = "스캔 ID로 3D 파일 경로와 메타데이터를 조회합니다. COMPLETED 상태의 스캔만 조회할 수 있습니다.", tags = "2. Scan")
     @GetMapping("/{scanId}/preview")
     public ApiResponse<GetScanResponse> getScanPreview(
@@ -53,15 +63,5 @@ public class ScanController {
 
         GetScanResponse response = scanService.getScanPreview(loginUser.userId(), scanId);
         return ApiResponse.success(200, "3D 스캔 결과 조회에 성공했습니다.", response);
-    }
-
-    @Operation(summary = "S06. 스캔 상태 조회", description = "스캔 ID로 현재 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다.", tags = "2. Scan")
-    @GetMapping("/{scanId}/status")
-    public ApiResponse<GetScanStatusResponse> getScanStatus(
-            @AuthenticationPrincipal LoginUser loginUser,
-            @Parameter(description = "조회할 스캔 ID", example = "12") @PathVariable Long scanId) {
-
-        GetScanStatusResponse response = scanService.getScanStatus(loginUser.userId(), scanId);
-        return ApiResponse.success(200, "스캔 상태 조회에 성공했습니다.", response);
     }
 }

--- a/src/main/java/com/roomlog/scan/controller/ScanController.java
+++ b/src/main/java/com/roomlog/scan/controller/ScanController.java
@@ -10,7 +10,6 @@ import com.roomlog.scan.dto.GetScanStatusResponse;
 import com.roomlog.scan.service.ScanService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/roomlog/scan/controller/ScanController.java
+++ b/src/main/java/com/roomlog/scan/controller/ScanController.java
@@ -24,27 +24,19 @@ public class ScanController {
 
     private final ScanService scanService;
 
-    @Operation(summary = "S04. 스캔 업로드", description = "LiDAR 스캔 결과 파일과 메타데이터를 서버에 업로드합니다. (임시 저장)")
+    @Operation(summary = "S04. 스캔 업로드", description = "LiDAR 스캔 결과 파일(.ply)을 서버에 업로드합니다. 업로드 직후 상태는 SCANNING이며, 처리 완료 시 COMPLETED로 변경됩니다.")
     @PostMapping(consumes = "multipart/form-data")
     public ApiResponse<CreateScanResponse> uploadScan(
             @AuthenticationPrincipal LoginUser loginUser,
             @RequestPart("file") MultipartFile file,
+            @Parameter(description = "스캔 타입 (IN: 입주, OUT: 퇴거)", example = "IN")
             @RequestParam("scan_type") Scan.ScanType scanType) {
 
         CreateScanResponse response = scanService.uploadScan(loginUser.userId(), file, new CreateScanRequest(scanType));
         return ApiResponse.success(201, "스캔 업로드에 성공했습니다.", response);
     }
 
-    @Operation(
-            summary = "S07. 스캔 미리보기",
-            description = """
-                    스캔 ID로 3D 스캔 결과 파일 정보를 조회합니다.
-
-                    - 스캔 상태가 COMPLETED인 경우에만 조회 가능합니다.
-                    - 상태가 COMPLETED가 아닌 경우 400(SCAN_004) 에러가 반환됩니다.
-                    - 존재하지 않는 scanId 요청 시 404(SCAN_001) 에러가 반환됩니다.
-                    """
-    )
+    @Operation(summary = "S07. 스캔 미리보기", description = "스캔 ID로 3D 파일 경로와 메타데이터를 조회합니다. COMPLETED 상태의 스캔만 조회할 수 있습니다.")
     @GetMapping("/{scanId}/preview")
     public ApiResponse<GetScanResponse> getScanPreview(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -54,17 +46,7 @@ public class ScanController {
         return ApiResponse.success(200, "스캔 결과 조회에 성공했습니다.", response);
     }
 
-    @Operation(
-            summary = "V01. 3D Viewer",
-            description = """
-                    스캔 ID로 .ply 기반 3D 파일 경로를 조회합니다.
-
-                    - 스캔 상태가 COMPLETED인 경우에만 조회 가능합니다.
-                    - 상태가 COMPLETED가 아닌 경우 400(SCAN_004) 에러가 반환됩니다.
-                    - 존재하지 않는 scanId 요청 시 404(SCAN_001) 에러가 반환됩니다.
-                    """,
-            tags = "3. Viewer"
-    )
+    @Operation(summary = "V01. 3D Viewer", description = "스캔 ID로 .ply 기반 3D 파일 경로를 조회합니다. COMPLETED 상태의 스캔만 조회할 수 있습니다.", tags = "3. Viewer")
     @GetMapping("/{scanId}/viewer")
     public ApiResponse<GetScanResponse> getScanViewer(
             @AuthenticationPrincipal LoginUser loginUser,
@@ -74,10 +56,7 @@ public class ScanController {
         return ApiResponse.success(200, "3D 스캔 결과 조회에 성공했습니다.", response);
     }
 
-    @Operation(
-            summary = "S06. 스캔 상태 조회",
-            description = "스캔 ID로 현재 스캔의 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다."
-    )
+    @Operation(summary = "S06. 스캔 상태 조회", description = "스캔 ID로 현재 처리 상태를 조회합니다. 상태는 SCANNING / COMPLETED / FAILED 중 하나입니다.")
     @GetMapping("/{scanId}/status")
     public ApiResponse<GetScanStatusResponse> getScanStatus(
             @AuthenticationPrincipal LoginUser loginUser,

--- a/src/main/java/com/roomlog/scan/domain/Scan.java
+++ b/src/main/java/com/roomlog/scan/domain/Scan.java
@@ -24,6 +24,9 @@ public class Scan {
     @Column(name = "scan_id")
     private Long id;
 
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
     @Column(name = "room_id")
     private Long roomId;
 
@@ -56,7 +59,8 @@ public class Scan {
     }
 
     @Builder
-    public Scan(Long roomId, String fileUrl, Status status, String thumbnailUrl, ScanType scanType) {
+    public Scan(Long userId, Long roomId, String fileUrl, Status status, String thumbnailUrl, ScanType scanType) {
+        this.userId = userId;
         this.roomId = roomId;
         this.fileUrl = fileUrl;
         this.status = status;

--- a/src/main/java/com/roomlog/scan/dto/GetRoomScansResponse.java
+++ b/src/main/java/com/roomlog/scan/dto/GetRoomScansResponse.java
@@ -1,0 +1,37 @@
+package com.roomlog.scan.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.room.domain.Room;
+import com.roomlog.scan.domain.Scan;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetRoomScansResponse {
+
+    @JsonProperty("room_id")
+    private final Long roomId;
+
+    @JsonProperty("room_name")
+    private final String roomName;
+
+    private final List<RoomScanListItemResponse> scans;
+
+    @JsonProperty("total_count")
+    private final int totalCount;
+
+    private GetRoomScansResponse(Room room, List<RoomScanListItemResponse> scans) {
+        this.roomId = room.getId();
+        this.roomName = room.getName();
+        this.scans = scans;
+        this.totalCount = scans.size();
+    }
+
+    public static GetRoomScansResponse of(Room room, List<Scan> scans) {
+        List<RoomScanListItemResponse> scanItems = scans.stream()
+                .map(RoomScanListItemResponse::from)
+                .toList();
+        return new GetRoomScansResponse(room, scanItems);
+    }
+}

--- a/src/main/java/com/roomlog/scan/dto/RoomScanListItemResponse.java
+++ b/src/main/java/com/roomlog/scan/dto/RoomScanListItemResponse.java
@@ -1,4 +1,37 @@
 package com.roomlog.scan.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.scan.domain.Scan;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class RoomScanListItemResponse {
+
+    @JsonProperty("scan_id")
+    private final Long scanId;
+
+    @JsonProperty("scan_type")
+    private final String scanType;
+
+    private final String status;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    @JsonProperty("thumbnail_url")
+    private final String thumbnailUrl;
+
+    private RoomScanListItemResponse(Scan scan) {
+        this.scanId = scan.getId();
+        this.scanType = scan.getScanType().name();
+        this.status = scan.getStatus().name();
+        this.createdAt = scan.getCreatedAt();
+        this.thumbnailUrl = scan.getThumbnailUrl();
+    }
+
+    public static RoomScanListItemResponse from(Scan scan) {
+        return new RoomScanListItemResponse(scan);
+    }
 }

--- a/src/main/java/com/roomlog/scan/service/ScanService.java
+++ b/src/main/java/com/roomlog/scan/service/ScanService.java
@@ -3,9 +3,14 @@ package com.roomlog.scan.service;
 import com.roomlog.global.exception.CustomException;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.global.infra.R2FileUploader;
+import com.roomlog.room.domain.Room;
+import com.roomlog.room.repository.RoomRepository;
 import com.roomlog.scan.domain.Scan;
+
+import java.util.List;
 import com.roomlog.scan.dto.CreateScanRequest;
 import com.roomlog.scan.dto.CreateScanResponse;
+import com.roomlog.scan.dto.GetRoomScansResponse;
 import com.roomlog.scan.dto.GetScanResponse;
 import com.roomlog.scan.dto.GetScanStatusResponse;
 import com.roomlog.scan.repository.ScanRepository;
@@ -19,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ScanService {
 
     private final ScanRepository scanRepository;
+    private final RoomRepository roomRepository;
     private final R2FileUploader r2FileUploader;
 
     @Transactional
@@ -55,6 +61,19 @@ public class ScanService {
         }
 
         return GetScanResponse.from(scan);
+    }
+
+    @Transactional(readOnly = true)
+    public GetRoomScansResponse getRoomScans(Long userId, Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        List<Scan> scans = scanRepository.findByRoomId(roomId);
+        return GetRoomScansResponse.of(room, scans);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/roomlog/scan/service/ScanService.java
+++ b/src/main/java/com/roomlog/scan/service/ScanService.java
@@ -3,8 +3,6 @@ package com.roomlog.scan.service;
 import com.roomlog.global.exception.CustomException;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.global.infra.R2FileUploader;
-import com.roomlog.room.domain.Room;
-import com.roomlog.room.repository.RoomRepository;
 import com.roomlog.scan.domain.Scan;
 import com.roomlog.scan.dto.CreateScanRequest;
 import com.roomlog.scan.dto.CreateScanResponse;
@@ -21,16 +19,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class ScanService {
 
     private final ScanRepository scanRepository;
-    private final RoomRepository roomRepository;
     private final R2FileUploader r2FileUploader;
 
     @Transactional
-    public CreateScanResponse uploadScan(MultipartFile file, CreateScanRequest request) {
+    public CreateScanResponse uploadScan(Long userId, MultipartFile file, CreateScanRequest request) {
         if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.COMMON_400, "스캔 파일이 없습니다.");
         }
 
         Scan scan = Scan.builder()
+                .userId(userId)
                 .scanType(request.getScanType())
                 .status(Scan.Status.SCANNING)
                 .build();
@@ -48,12 +46,8 @@ public class ScanService {
         Scan scan = scanRepository.findById(scanId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SCAN_001));
 
-        if (scan.getRoomId() != null) {
-            Room room = roomRepository.findById(scan.getRoomId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.SCAN_001));
-            if (!room.getUserId().equals(userId)) {
-                throw new CustomException(ErrorCode.COMMON_403);
-            }
+        if (!scan.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMON_403);
         }
 
         if (scan.getStatus() != Scan.Status.COMPLETED) {
@@ -68,12 +62,8 @@ public class ScanService {
         Scan scan = scanRepository.findById(scanId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SCAN_001));
 
-        if (scan.getRoomId() != null) {
-            Room room = roomRepository.findById(scan.getRoomId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.SCAN_001));
-            if (!room.getUserId().equals(userId)) {
-                throw new CustomException(ErrorCode.COMMON_403);
-            }
+        if (!scan.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMON_403);
         }
 
         return GetScanStatusResponse.from(scan);

--- a/src/main/java/com/roomlog/user/controller/UserController.java
+++ b/src/main/java/com/roomlog/user/controller/UserController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "9. 마이페이지", description = "프로필 조회, 내 정보 수정, 회원 탈퇴 API")
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
@@ -22,14 +21,14 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "M01. 내 프로필 조회", description = "로그인한 사용자의 프로필 정보를 조회합니다.")
+    @Operation(summary = "M01. 내 프로필 조회", description = "로그인한 사용자의 프로필 정보를 조회합니다.", tags = "7. MyPage")
     @GetMapping
     public ApiResponse<GetMyProfileResponse> getMyProfile(@AuthenticationPrincipal LoginUser loginUser) {
         GetMyProfileResponse response = userService.getMyProfile(loginUser.userId());
         return ApiResponse.success(200, "내 정보 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "M02. 내 정보 수정", description = "닉네임을 수정합니다.")
+    @Operation(summary = "M02. 내 정보 수정", description = "닉네임을 수정합니다.", tags = "7. MyPage")
     @PatchMapping
     public ApiResponse<UpdateUserResponse> updateUser(@AuthenticationPrincipal LoginUser loginUser,
                                                       @Valid @RequestBody UpdateUserRequest request) {
@@ -37,7 +36,7 @@ public class UserController {
         return ApiResponse.success(200, "내 정보 수정에 성공했습니다.", response);
     }
 
-    @Operation(summary = "M04. 회원 탈퇴", description = "계정을 삭제합니다. (soft delete)")
+    @Operation(summary = "M04. 회원 탈퇴", description = "계정을 삭제합니다. (soft delete)", tags = "7. MyPage")
     @DeleteMapping
     public ApiResponse<DeleteUserResponse> deleteUser(@AuthenticationPrincipal LoginUser loginUser) {
         DeleteUserResponse response = userService.deleteUser(loginUser.userId());

--- a/src/main/java/com/roomlog/user/controller/UserController.java
+++ b/src/main/java/com/roomlog/user/controller/UserController.java
@@ -8,7 +8,6 @@ import com.roomlog.user.dto.UpdateUserRequest;
 import com.roomlog.user.dto.UpdateUserResponse;
 import com.roomlog.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/roomlog/user/controller/UserController.java
+++ b/src/main/java/com/roomlog/user/controller/UserController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "3. 마이페이지", description = "프로필 조회, 내 정보 수정, 회원 탈퇴 API")
+@Tag(name = "9. 마이페이지", description = "프로필 조회, 내 정보 수정, 회원 탈퇴 API")
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 springdoc:
   swagger-ui:
     tags-sorter: alpha
-Y
+
 server:
   port: ${PORT:8080}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
       max-file-size: 500MB
       max-request-size: 500MB
 
+springdoc:
+  swagger-ui:
+    tags-sorter: alpha
+
 server:
   port: ${PORT:8080}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 springdoc:
   swagger-ui:
     tags-sorter: alpha
-
+Y
 server:
   port: ${PORT:8080}
 
@@ -15,3 +15,6 @@ jwt:
   secret: ${JWT_SECRET:roomlog-secret-key-must-be-at-least-32-characters-long}
   expiration: 86400000
   refresh-expiration: 1209600000
+
+ai:
+  api-key: ${AI_API_KEY:roomlog-ai-secret-key}


### PR DESCRIPTION
## 📌 작업 내용
- viewer 기능 구현

## 🛠 변경 사항
- 순수 3D Viewer api 개발
- 입주/퇴거 room 목록 조회 api 개발
- 하자 분석 생성 api 개발
- 하자 분석 결과 조회 api 개발
- 하자 위치 표시 api 개발
- 하자 상세 조회 api 개발
- 수리비 요약 조회 api 개발
- 수리 비용을 공공데이터, 심각도, 하자 유형을 이용하여 구현
### 
- 수리 비용 전체 흐름은 아래처럼 진행
AI가 (type, severity, area) 전송
            ↓
  DB에서 unitPrice 조회 (type 기준)
            ↓
  estimatedCost 계산 후 각 Defect에 저장
            ↓
  analysis.totalCost = 모든 defect estimatedCost 합산

## 🔗 관련 이슈
- Closes #27 

## ✅ 테스트
- [x] 정상 동작 확인
- [x] 에러 케이스 확인

## 📸 결과 (선택)
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create/retrieve analyses with cost breakdown; view defect details; 3D scan viewer; fetch scans per room; AI-result submission guarded by API key
* **Documentation**
  * API spec updated for room-scoped scan flows; Swagger tags reorganized and sorted; added error code for already-processed analyses
* **Data Model**
  * Severity label changed from "MID" → "MEDIUM"; added per-unit defect pricing and initial seed values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->