### PR TITLE
[Feat] defect 테이블에 inspection_image_url 칼럼 추가 및 v03, v05에 해당 칼럼 추가

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -64,8 +64,9 @@ severity varchar // 심각도 (LOW / MEDIUM / HIGH)
 location varchar // 사람이 읽는 위치 설명
 area float // 면적
 estimated_cost int // 예상 비용
-before_image_url varchar [null] // 입주 상태 이미지
-after_image_url varchar [null] // 퇴거 상태 이미지
+before_image_url varchar [null] // 입주 전 하자 부위 이미지
+after_image_url varchar [null] // 입주 후/퇴거 하자 부위 이미지
+inspection_image_url varchar [null] // 하자점검 상세 기본 표시 이미지
 description varchar [null] // 상세 설명
 x float [null] // 3D 좌표 X
 y float [null] // 3D 좌표 Y

--- a/src/main/java/com/roomlog/analysis/dto/AiResultRequest.java
+++ b/src/main/java/com/roomlog/analysis/dto/AiResultRequest.java
@@ -29,6 +29,9 @@ public class AiResultRequest {
         @JsonProperty("after_image_url")
         private String afterImageUrl;
 
+        @JsonProperty("inspection_image_url")
+        private String inspectionImageUrl;
+
         private Float x;
         private Float y;
         private Float z;

--- a/src/main/java/com/roomlog/analysis/service/AnalysisService.java
+++ b/src/main/java/com/roomlog/analysis/service/AnalysisService.java
@@ -111,6 +111,7 @@ public class AnalysisService {
                             .estimatedCost(estimatedCost)
                             .beforeImageUrl(item.getBeforeImageUrl())
                             .afterImageUrl(item.getAfterImageUrl())
+                            .inspectionImageUrl(item.getInspectionImageUrl())
                             .description(item.getDescription())
                             .x(item.getX())
                             .y(item.getY())

--- a/src/main/java/com/roomlog/defect/domain/Defect.java
+++ b/src/main/java/com/roomlog/defect/domain/Defect.java
@@ -45,6 +45,9 @@ public class Defect {
     @Column(name = "after_image_url")
     private String afterImageUrl;
 
+    @Column(name = "inspection_image_url")
+    private String inspectionImageUrl;
+
     @Column
     private String description;
 
@@ -71,7 +74,7 @@ public class Defect {
     @Builder
     public Defect(Long analysisId, String type, String severity, String location, Float area,
                   Integer estimatedCost, String beforeImageUrl, String afterImageUrl,
-                  String description, Float x, Float y, Float z) {
+                  String inspectionImageUrl, String description, Float x, Float y, Float z) {
         this.analysisId = analysisId;
         this.type = type;
         this.severity = severity;
@@ -80,6 +83,7 @@ public class Defect {
         this.estimatedCost = estimatedCost;
         this.beforeImageUrl = beforeImageUrl;
         this.afterImageUrl = afterImageUrl;
+        this.inspectionImageUrl = inspectionImageUrl;
         this.description = description;
         this.x = x;
         this.y = y;

--- a/src/main/java/com/roomlog/defect/dto/DefectItemResponse.java
+++ b/src/main/java/com/roomlog/defect/dto/DefectItemResponse.java
@@ -33,6 +33,9 @@ public class DefectItemResponse {
     @JsonProperty("after_image_url")
     private final String afterImageUrl;
 
+    @JsonProperty("inspection_image_url")
+    private final String inspectionImageUrl;
+
     private DefectItemResponse(Defect defect) {
         this.defectId = defect.getId();
         this.type = defect.getType();
@@ -45,6 +48,7 @@ public class DefectItemResponse {
         this.z = defect.getZ();
         this.beforeImageUrl = defect.getBeforeImageUrl();
         this.afterImageUrl = defect.getAfterImageUrl();
+        this.inspectionImageUrl = defect.getInspectionImageUrl();
     }
 
     public static DefectItemResponse from(Defect defect) {

--- a/src/main/java/com/roomlog/defect/dto/GetDefectDetailResponse.java
+++ b/src/main/java/com/roomlog/defect/dto/GetDefectDetailResponse.java
@@ -38,6 +38,9 @@ public class GetDefectDetailResponse {
     @JsonProperty("after_image_url")
     private final String afterImageUrl;
 
+    @JsonProperty("inspection_image_url")
+    private final String inspectionImageUrl;
+
     private GetDefectDetailResponse(Defect defect) {
         this.defectId = defect.getId();
         this.analysisId = defect.getAnalysisId();
@@ -52,6 +55,7 @@ public class GetDefectDetailResponse {
         this.description = defect.getDescription();
         this.beforeImageUrl = defect.getBeforeImageUrl();
         this.afterImageUrl = defect.getAfterImageUrl();
+        this.inspectionImageUrl = defect.getInspectionImageUrl();
     }
 
     public static GetDefectDetailResponse from(Defect defect) {


### PR DESCRIPTION
## 📌 작업 내용
- defect 테이블에 inspection_image_url 칼럼 추가 및 v03, v05에 해당 칼럼 추가

## 🛠 변경 사항
- erd 수정
- v03 성공 바디 값 수정
- v05 성공 바디 값 수정

## 🔗 관련 이슈
- Closes #

## ✅ 테스트
- [x] 정상 동작 확인
- [x] 에러 케이스 확인

## 📸 결과 (선택)
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Defects now support a default inspection image field, allowing users to associate a detailed inspection display image alongside existing before and after images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->