### PR TITLE
[Feat] 수리 api 일부 개발 및 swagger에 서버 경로 고정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.25.0')
     implementation 'software.amazon.awssdk:s3'
 
+    // Solapi SMS
+    implementation 'net.nurigo:sdk:4.3.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -83,7 +83,6 @@ analysis_id int [ref: > Analysis.analysis_id] // 분석 결과 FK
 provider_name varchar // 업체명
 provider_phone varchar [null] // 전화번호
 provider_address varchar [null] // 주소
-provider_rating float [null] // 평점
 provider_image_url varchar [null] // 업체 이미지 URL
 provider_external_id varchar [null] // 카카오 place id
 provider_lat float [null] // 업체 위도

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -28,3 +28,4 @@ ESTIMATE_003 : 해당 견적 요청에 접근 권한이 없습니다. #403 Forbi
 REPAIR_001 : 존재하지 않는 수리 내역입니다. #404 Not Found
 
 REPAIRSHOP_001 : 추천 가능한 수리 업체가 없습니다. #404 Not Found
+REPAIRSHOP_002 : 업체 정보를 찾을 수 없습니다. #404 Not Found

--- a/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/roomlog/analysis/controller/AnalysisController.java
@@ -5,7 +5,9 @@ import com.roomlog.analysis.dto.CreateAnalysisRequest;
 import com.roomlog.analysis.dto.CreateAnalysisResponse;
 import com.roomlog.analysis.dto.GetAnalysisCostResponse;
 import com.roomlog.analysis.dto.GetAnalysisResponse;
+import com.roomlog.analysis.dto.GetRepairShopsResponse;
 import com.roomlog.analysis.service.AnalysisService;
+import com.roomlog.analysis.service.RepairShopService;
 import com.roomlog.global.response.ApiResponse;
 import com.roomlog.global.security.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
+    private final RepairShopService repairShopService;
 
     @Operation(summary = "AI 분석 결과 수신 (내부 전용)", description = "AI 서버가 분석 완료 후 하자 목록을 전송하는 내부 API입니다. X-Api-Key 헤더 인증이 필요합니다.", tags = "0. Internal")
     @PostMapping("/{analysisId}/result")
@@ -50,6 +53,19 @@ public class AnalysisController {
 
         GetAnalysisCostResponse response = analysisService.getAnalysisCost(loginUser.userId(), analysisId);
         return ApiResponse.success(200, "수리비 요약 조회에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "R01. 수리 업체 리스트 조회", description = "분석 ID 기준 방 주소를 좌표로 변환 후 카카오 지도 API로 주변 수리 업체를 조회합니다.", tags = "5. Repair")
+    @GetMapping("/{analysisId}/repair-shops")
+    public ApiResponse<GetRepairShopsResponse> getRepairShops(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "분석 ID", example = "5") @PathVariable Long analysisId,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false, defaultValue = "3km") String radius,
+            @RequestParam(required = false, defaultValue = "distance") String sort) {
+
+        GetRepairShopsResponse response = repairShopService.getRepairShops(loginUser.userId(), analysisId, type, radius, sort);
+        return ApiResponse.success(200, "수리 업체 리스트 조회에 성공했습니다.", response);
     }
 
     @Operation(summary = "V03. 분석 결과 조회", description = "분석 ID로 하자 분석 결과를 조회합니다. COMPLETED 상태의 분석만 조회할 수 있습니다.", tags = "3. Viewer")

--- a/src/main/java/com/roomlog/analysis/dto/GetRepairShopsResponse.java
+++ b/src/main/java/com/roomlog/analysis/dto/GetRepairShopsResponse.java
@@ -1,0 +1,36 @@
+package com.roomlog.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetRepairShopsResponse {
+
+    @JsonProperty("analysis_id")
+    private final Long analysisId;
+
+    private final String type;
+    private final String radius;
+    private final String sort;
+
+    @JsonProperty("repair_shops")
+    private final List<RepairShopResponse> repairShops;
+
+    @JsonProperty("total_count")
+    private final int totalCount;
+
+    private GetRepairShopsResponse(Long analysisId, String type, String radius, String sort, List<RepairShopResponse> repairShops) {
+        this.analysisId = analysisId;
+        this.type = type;
+        this.radius = radius;
+        this.sort = sort;
+        this.repairShops = repairShops;
+        this.totalCount = repairShops.size();
+    }
+
+    public static GetRepairShopsResponse of(Long analysisId, String type, String radius, String sort, List<RepairShopResponse> repairShops) {
+        return new GetRepairShopsResponse(analysisId, type, radius, sort, repairShops);
+    }
+}

--- a/src/main/java/com/roomlog/analysis/dto/RepairShopResponse.java
+++ b/src/main/java/com/roomlog/analysis/dto/RepairShopResponse.java
@@ -1,4 +1,51 @@
 package com.roomlog.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.global.infra.KakaoLocalClient.KakaoPlace;
+import lombok.Getter;
+
+@Getter
 public class RepairShopResponse {
+
+    @JsonProperty("provider_external_id")
+    private final String providerExternalId;
+
+    @JsonProperty("provider_name")
+    private final String providerName;
+
+    @JsonProperty("provider_phone")
+    private final String providerPhone;
+
+    @JsonProperty("provider_address")
+    private final String providerAddress;
+
+    @JsonProperty("provider_lat")
+    private final Double providerLat;
+
+    @JsonProperty("provider_lng")
+    private final Double providerLng;
+
+    private final Double distance;
+
+    @JsonProperty("provider_image_url")
+    private final String providerImageUrl;
+
+    private RepairShopResponse(KakaoPlace place) {
+        this.providerExternalId = place.getId();
+        this.providerName = place.getPlaceName();
+        this.providerPhone = place.getPhone();
+        this.providerAddress = place.getRoadAddressName() != null && !place.getRoadAddressName().isBlank()
+                ? place.getRoadAddressName()
+                : place.getAddressName();
+        this.providerLat = place.getY() != null ? Double.parseDouble(place.getY()) : null;
+        this.providerLng = place.getX() != null ? Double.parseDouble(place.getX()) : null;
+        this.distance = place.getDistance() != null && !place.getDistance().isBlank()
+                ? Double.parseDouble(place.getDistance()) / 1000.0
+                : null;
+        this.providerImageUrl = null;
+    }
+
+    public static RepairShopResponse from(KakaoPlace place) {
+        return new RepairShopResponse(place);
+    }
 }

--- a/src/main/java/com/roomlog/analysis/service/RepairShopService.java
+++ b/src/main/java/com/roomlog/analysis/service/RepairShopService.java
@@ -1,4 +1,82 @@
 package com.roomlog.analysis.service;
 
+import com.roomlog.analysis.domain.Analysis;
+import com.roomlog.analysis.dto.GetRepairShopsResponse;
+import com.roomlog.analysis.dto.RepairShopResponse;
+import com.roomlog.analysis.repository.AnalysisRepository;
+import com.roomlog.global.exception.CustomException;
+import com.roomlog.global.exception.ErrorCode;
+import com.roomlog.global.infra.KakaoLocalClient;
+import com.roomlog.global.infra.KakaoLocalClient.KakaoPlace;
+import com.roomlog.room.domain.Room;
+import com.roomlog.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
 public class RepairShopService {
+
+    private static final Map<String, String> TYPE_KEYWORD_MAP = Map.of(
+            "SCRATCH", "스크래치 수리 업체",
+            "CRACK", "균열 보수 업체",
+            "PEELING", "도배 업체",
+            "STAIN", "도배 청소 업체",
+            "BREAKAGE", "파손 수리 업체"
+    );
+
+    private final AnalysisRepository analysisRepository;
+    private final RoomRepository roomRepository;
+    private final KakaoLocalClient kakaoLocalClient;
+
+    @Transactional(readOnly = true)
+    public GetRepairShopsResponse getRepairShops(Long userId, Long analysisId, String type, String radius, String sort) {
+        Analysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_001));
+
+        Room room = roomRepository.findById(analysis.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        double[] coords = kakaoLocalClient.geocodeAddress(room.getAddress());
+        if (coords == null) {
+            throw new CustomException(ErrorCode.REPAIRSHOP_001);
+        }
+
+        String keyword = TYPE_KEYWORD_MAP.getOrDefault(
+                type != null ? type.toUpperCase() : "", "인테리어 수리 업체");
+        int radiusMeters = parseRadiusToMeters(radius);
+        String sortParam = (sort != null && sort.equals("accuracy")) ? "accuracy" : "distance";
+
+        List<KakaoPlace> places = kakaoLocalClient.searchKeyword(keyword, coords[0], coords[1], radiusMeters, sortParam);
+
+        if (places == null || places.isEmpty()) {
+            throw new CustomException(ErrorCode.REPAIRSHOP_001);
+        }
+
+        List<RepairShopResponse> repairShops = places.stream()
+                .map(RepairShopResponse::from)
+                .toList();
+
+        return GetRepairShopsResponse.of(analysisId, type, radius, sort, repairShops);
+    }
+
+    private int parseRadiusToMeters(String radius) {
+        if (radius == null || radius.isBlank()) return 3000;
+        String lower = radius.toLowerCase().trim();
+        if (lower.endsWith("km")) {
+            return (int) (Double.parseDouble(lower.replace("km", "")) * 1000);
+        }
+        if (lower.endsWith("m")) {
+            return Integer.parseInt(lower.replace("m", ""));
+        }
+        return 3000;
+    }
 }

--- a/src/main/java/com/roomlog/estimate/controller/EstimateController.java
+++ b/src/main/java/com/roomlog/estimate/controller/EstimateController.java
@@ -1,9 +1,32 @@
 package com.roomlog.estimate.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.roomlog.estimate.dto.EstimatePreviewRequest;
+import com.roomlog.estimate.dto.EstimatePreviewResponse;
+import com.roomlog.estimate.service.EstimateService;
+import com.roomlog.global.response.ApiResponse;
+import com.roomlog.global.security.LoginUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/estimates")
+@RequiredArgsConstructor
+@Tag(name = "5. Repair")
 public class EstimateController {
+
+    private final EstimateService estimateService;
+
+    @Operation(summary = "R02. 견적 요청 미리보기", description = "선택한 업체와 분석 결과 하자 정보를 기반으로 문의 내용 및 요약 정보를 미리 조회합니다. 실제 견적 요청 전 확인 화면에 사용합니다.", tags = "5. Repair")
+    @PostMapping("/preview")
+    public ApiResponse<EstimatePreviewResponse> previewEstimate(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Valid @RequestBody EstimatePreviewRequest request) {
+
+        EstimatePreviewResponse response = estimateService.previewEstimate(loginUser.userId(), request);
+        return ApiResponse.success(200, "견적 요청 미리보기에 성공했습니다.", response);
+    }
 }

--- a/src/main/java/com/roomlog/estimate/controller/EstimateController.java
+++ b/src/main/java/com/roomlog/estimate/controller/EstimateController.java
@@ -1,5 +1,7 @@
 package com.roomlog.estimate.controller;
 
+import com.roomlog.estimate.dto.CreateEstimateRequest;
+import com.roomlog.estimate.dto.CreateEstimateResponse;
 import com.roomlog.estimate.dto.EstimatePreviewRequest;
 import com.roomlog.estimate.dto.EstimatePreviewResponse;
 import com.roomlog.estimate.service.EstimateService;
@@ -28,5 +30,15 @@ public class EstimateController {
 
         EstimatePreviewResponse response = estimateService.previewEstimate(loginUser.userId(), request);
         return ApiResponse.success(200, "견적 요청 미리보기에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "R02-1. 견적 요청", description = "선택한 하자와 업체 정보를 기반으로 문의 문구를 생성하고 견적 요청 이력을 저장합니다.", tags = "5. Repair")
+    @PostMapping
+    public ApiResponse<CreateEstimateResponse> createEstimate(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Valid @RequestBody CreateEstimateRequest request) {
+
+        CreateEstimateResponse response = estimateService.createEstimate(loginUser.userId(), request);
+        return ApiResponse.success(201, "견적 요청이 완료되었습니다.", response);
     }
 }

--- a/src/main/java/com/roomlog/estimate/domain/Estimate.java
+++ b/src/main/java/com/roomlog/estimate/domain/Estimate.java
@@ -71,6 +71,10 @@ public class Estimate {
         this.createdAt = LocalDateTime.now();
     }
 
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
+
     public void softDelete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/roomlog/estimate/domain/Estimate.java
+++ b/src/main/java/com/roomlog/estimate/domain/Estimate.java
@@ -41,9 +41,6 @@ public class Estimate {
     @Column(name = "provider_address")
     private String providerAddress;
 
-    @Column(name = "provider_rating")
-    private Float providerRating;
-
     @Column(name = "provider_external_id")
     private String providerExternalId;
 
@@ -81,7 +78,7 @@ public class Estimate {
 
     @Builder
     public Estimate(Long userId, Long roomId, Long analysisId, String providerName,
-                    String providerPhone, String providerAddress, Float providerRating,
+                    String providerPhone, String providerAddress,
                     String providerExternalId, Float providerLat, Float providerLng, String message) {
         this.userId = userId;
         this.roomId = roomId;
@@ -89,7 +86,6 @@ public class Estimate {
         this.providerName = providerName;
         this.providerPhone = providerPhone;
         this.providerAddress = providerAddress;
-        this.providerRating = providerRating;
         this.providerExternalId = providerExternalId;
         this.providerLat = providerLat;
         this.providerLng = providerLng;

--- a/src/main/java/com/roomlog/estimate/dto/CreateEstimateRequest.java
+++ b/src/main/java/com/roomlog/estimate/dto/CreateEstimateRequest.java
@@ -1,4 +1,39 @@
 package com.roomlog.estimate.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
 public class CreateEstimateRequest {
+
+    @NotNull
+    @JsonProperty("room_id")
+    private Long roomId;
+
+    @NotNull
+    @JsonProperty("analysis_id")
+    private Long analysisId;
+
+    @NotEmpty
+    @JsonProperty("defect_ids")
+    private List<Long> defectIds;
+
+    @NotBlank
+    @JsonProperty("provider_name")
+    private String providerName;
+
+    @JsonProperty("provider_phone")
+    private String providerPhone;
+
+    @JsonProperty("provider_address")
+    private String providerAddress;
+
+    private String message;
 }

--- a/src/main/java/com/roomlog/estimate/dto/CreateEstimateResponse.java
+++ b/src/main/java/com/roomlog/estimate/dto/CreateEstimateResponse.java
@@ -1,4 +1,19 @@
 package com.roomlog.estimate.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
 public class CreateEstimateResponse {
+
+    @JsonProperty("estimate_id")
+    private final Long estimateId;
+
+    private CreateEstimateResponse(Long estimateId) {
+        this.estimateId = estimateId;
+    }
+
+    public static CreateEstimateResponse of(Long estimateId) {
+        return new CreateEstimateResponse(estimateId);
+    }
 }

--- a/src/main/java/com/roomlog/estimate/dto/EstimatePreviewRequest.java
+++ b/src/main/java/com/roomlog/estimate/dto/EstimatePreviewRequest.java
@@ -1,0 +1,22 @@
+package com.roomlog.estimate.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EstimatePreviewRequest {
+
+    @NotNull
+    @JsonProperty("analysis_id")
+    private Long analysisId;
+
+    @NotBlank
+    @JsonProperty("provider_external_id")
+    private String providerExternalId;
+
+    private String message;
+}

--- a/src/main/java/com/roomlog/estimate/dto/EstimatePreviewResponse.java
+++ b/src/main/java/com/roomlog/estimate/dto/EstimatePreviewResponse.java
@@ -1,0 +1,128 @@
+package com.roomlog.estimate.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roomlog.defect.domain.Defect;
+import com.roomlog.global.infra.KakaoLocalClient.KakaoPlace;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class EstimatePreviewResponse {
+
+    @JsonProperty("analysis_id")
+    private final Long analysisId;
+
+    @JsonProperty("room_id")
+    private final Long roomId;
+
+    private final ProviderInfo provider;
+    private final List<DefectSummary> defects;
+    private final Summary summary;
+
+    @JsonProperty("message_preview")
+    private final String messagePreview;
+
+    private EstimatePreviewResponse(Long analysisId, Long roomId, ProviderInfo provider,
+                                    List<DefectSummary> defects, String messagePreview) {
+        this.analysisId = analysisId;
+        this.roomId = roomId;
+        this.provider = provider;
+        this.defects = defects;
+        this.summary = Summary.from(defects);
+        this.messagePreview = messagePreview;
+    }
+
+    public static EstimatePreviewResponse of(Long analysisId, Long roomId, KakaoPlace place,
+                                             List<Defect> defects, String userMessage) {
+        ProviderInfo provider = ProviderInfo.from(place);
+        List<DefectSummary> defectSummaries = defects.stream().map(DefectSummary::from).toList();
+        int totalCost = defects.stream().mapToInt(Defect::getEstimatedCost).sum();
+        String messagePreview = buildMessagePreview(defects.size(), totalCost, userMessage);
+        return new EstimatePreviewResponse(analysisId, roomId, provider, defectSummaries, messagePreview);
+    }
+
+    private static String buildMessagePreview(int defectCount, int totalCost, String userMessage) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("안녕하세요. RoomLog를 통해 문의드립니다.\n");
+        sb.append(String.format("현재 총 %d건의 하자가 확인되었으며 예상 수리비는 약 %,d원입니다.\n", defectCount, totalCost));
+        if (userMessage != null && !userMessage.isBlank()) {
+            sb.append(userMessage);
+        }
+        return sb.toString();
+    }
+
+    @Getter
+    public static class ProviderInfo {
+
+        @JsonProperty("provider_external_id")
+        private final String providerExternalId;
+
+        @JsonProperty("provider_name")
+        private final String providerName;
+
+        @JsonProperty("provider_phone")
+        private final String providerPhone;
+
+        @JsonProperty("provider_address")
+        private final String providerAddress;
+
+        private ProviderInfo(KakaoPlace place) {
+            this.providerExternalId = place.getId();
+            this.providerName = place.getPlaceName();
+            this.providerPhone = place.getPhone();
+            this.providerAddress = place.getRoadAddressName() != null && !place.getRoadAddressName().isBlank()
+                    ? place.getRoadAddressName()
+                    : place.getAddressName();
+        }
+
+        public static ProviderInfo from(KakaoPlace place) {
+            return new ProviderInfo(place);
+        }
+    }
+
+    @Getter
+    public static class DefectSummary {
+
+        @JsonProperty("defect_id")
+        private final Long defectId;
+
+        private final String type;
+        private final String location;
+        private final String severity;
+
+        @JsonProperty("estimated_cost")
+        private final Integer estimatedCost;
+
+        private DefectSummary(Defect defect) {
+            this.defectId = defect.getId();
+            this.type = defect.getType();
+            this.location = defect.getLocation();
+            this.severity = defect.getSeverity();
+            this.estimatedCost = defect.getEstimatedCost();
+        }
+
+        public static DefectSummary from(Defect defect) {
+            return new DefectSummary(defect);
+        }
+    }
+
+    @Getter
+    public static class Summary {
+
+        @JsonProperty("defect_count")
+        private final int defectCount;
+
+        @JsonProperty("total_cost")
+        private final int totalCost;
+
+        private Summary(List<DefectSummary> defects) {
+            this.defectCount = defects.size();
+            this.totalCost = defects.stream().mapToInt(DefectSummary::getEstimatedCost).sum();
+        }
+
+        public static Summary from(List<DefectSummary> defects) {
+            return new Summary(defects);
+        }
+    }
+}

--- a/src/main/java/com/roomlog/estimate/service/EstimateService.java
+++ b/src/main/java/com/roomlog/estimate/service/EstimateService.java
@@ -4,12 +4,19 @@ import com.roomlog.analysis.domain.Analysis;
 import com.roomlog.analysis.repository.AnalysisRepository;
 import com.roomlog.defect.domain.Defect;
 import com.roomlog.defect.repository.DefectRepository;
+import com.roomlog.estimate.domain.Estimate;
+import com.roomlog.estimate.domain.EstimateDefect;
+import com.roomlog.estimate.dto.CreateEstimateRequest;
+import com.roomlog.estimate.dto.CreateEstimateResponse;
 import com.roomlog.estimate.dto.EstimatePreviewRequest;
 import com.roomlog.estimate.dto.EstimatePreviewResponse;
+import com.roomlog.estimate.repository.EstimateDefectRepository;
+import com.roomlog.estimate.repository.EstimateRepository;
 import com.roomlog.global.exception.CustomException;
 import com.roomlog.global.exception.ErrorCode;
 import com.roomlog.global.infra.KakaoLocalClient;
 import com.roomlog.global.infra.KakaoLocalClient.KakaoPlace;
+import com.roomlog.global.infra.SmsService;
 import com.roomlog.room.domain.Room;
 import com.roomlog.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +32,10 @@ public class EstimateService {
     private final AnalysisRepository analysisRepository;
     private final RoomRepository roomRepository;
     private final DefectRepository defectRepository;
+    private final EstimateRepository estimateRepository;
+    private final EstimateDefectRepository estimateDefectRepository;
     private final KakaoLocalClient kakaoLocalClient;
+    private final SmsService smsService;
 
     @Transactional(readOnly = true)
     public EstimatePreviewResponse previewEstimate(Long userId, EstimatePreviewRequest request) {
@@ -47,5 +57,70 @@ public class EstimateService {
         List<Defect> defects = defectRepository.findByAnalysisId(request.getAnalysisId());
 
         return EstimatePreviewResponse.of(analysis.getId(), room.getId(), place, defects, request.getMessage());
+    }
+
+    @Transactional
+    public CreateEstimateResponse createEstimate(Long userId, CreateEstimateRequest request) {
+        Room room = roomRepository.findById(request.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        analysisRepository.findById(request.getAnalysisId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_001));
+
+        List<Defect> defects = defectRepository.findAllById(request.getDefectIds());
+        if (defects.size() != request.getDefectIds().size()) {
+            throw new CustomException(ErrorCode.DEFECT_001);
+        }
+
+        try {
+            Estimate estimate = Estimate.builder()
+                    .userId(userId)
+                    .roomId(request.getRoomId())
+                    .analysisId(request.getAnalysisId())
+                    .providerName(request.getProviderName())
+                    .providerPhone(request.getProviderPhone())
+                    .providerAddress(request.getProviderAddress())
+                    .message(request.getMessage())
+                    .build();
+            estimateRepository.save(estimate);
+
+            List<EstimateDefect> estimateDefects = defects.stream()
+                    .map(d -> EstimateDefect.builder()
+                            .estimateId(estimate.getId())
+                            .defectId(d.getId())
+                            .build())
+                    .toList();
+            estimateDefectRepository.saveAll(estimateDefects);
+
+            if (request.getProviderPhone() != null && !request.getProviderPhone().isBlank()) {
+                String smsText = buildSmsText(defects.size(), totalCost(defects), request.getMessage());
+                boolean sent = smsService.send(request.getProviderPhone(), smsText);
+                estimate.updateStatus(sent ? Estimate.Status.SENT : Estimate.Status.FAILED);
+            }
+
+            return CreateEstimateResponse.of(estimate.getId());
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.ESTIMATE_001);
+        }
+    }
+
+    private String buildSmsText(int defectCount, int totalCost, String userMessage) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("안녕하세요. RoomLog를 통해 문의드립니다.\n");
+        sb.append(String.format("현재 총 %d건의 하자가 확인되었으며 예상 수리비는 약 %,d원입니다.\n", defectCount, totalCost));
+        if (userMessage != null && !userMessage.isBlank()) {
+            sb.append(userMessage);
+        }
+        return sb.toString();
+    }
+
+    private int totalCost(List<Defect> defects) {
+        return defects.stream().mapToInt(Defect::getEstimatedCost).sum();
     }
 }

--- a/src/main/java/com/roomlog/estimate/service/EstimateService.java
+++ b/src/main/java/com/roomlog/estimate/service/EstimateService.java
@@ -1,4 +1,51 @@
 package com.roomlog.estimate.service;
 
+import com.roomlog.analysis.domain.Analysis;
+import com.roomlog.analysis.repository.AnalysisRepository;
+import com.roomlog.defect.domain.Defect;
+import com.roomlog.defect.repository.DefectRepository;
+import com.roomlog.estimate.dto.EstimatePreviewRequest;
+import com.roomlog.estimate.dto.EstimatePreviewResponse;
+import com.roomlog.global.exception.CustomException;
+import com.roomlog.global.exception.ErrorCode;
+import com.roomlog.global.infra.KakaoLocalClient;
+import com.roomlog.global.infra.KakaoLocalClient.KakaoPlace;
+import com.roomlog.room.domain.Room;
+import com.roomlog.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class EstimateService {
+
+    private final AnalysisRepository analysisRepository;
+    private final RoomRepository roomRepository;
+    private final DefectRepository defectRepository;
+    private final KakaoLocalClient kakaoLocalClient;
+
+    @Transactional(readOnly = true)
+    public EstimatePreviewResponse previewEstimate(Long userId, EstimatePreviewRequest request) {
+        Analysis analysis = analysisRepository.findById(request.getAnalysisId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_001));
+
+        Room room = roomRepository.findById(analysis.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_001));
+
+        if (!room.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROOM_002);
+        }
+
+        KakaoPlace place = kakaoLocalClient.getPlaceById(request.getProviderExternalId());
+        if (place == null) {
+            throw new CustomException(ErrorCode.REPAIRSHOP_002);
+        }
+
+        List<Defect> defects = defectRepository.findByAnalysisId(request.getAnalysisId());
+
+        return EstimatePreviewResponse.of(analysis.getId(), room.getId(), place, defects, request.getMessage());
+    }
 }

--- a/src/main/java/com/roomlog/global/config/AppConfig.java
+++ b/src/main/java/com/roomlog/global/config/AppConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -11,5 +12,10 @@ public class AppConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/roomlog/global/config/SwaggerConfig.java
+++ b/src/main/java/com/roomlog/global/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +20,7 @@ public class SwaggerConfig {
         String securitySchemeName = "BearerAuth";
 
         return new OpenAPI()
+                .servers(List.of(new Server().url("https://roomlog-server-production.up.railway.app")))
                 .info(new Info()
                         .title("RoomLog API")
                         .description("RoomLog 서버 API 명세서")

--- a/src/main/java/com/roomlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/roomlog/global/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     DEFECT_001(HttpStatus.NOT_FOUND, "DEFECT_001", "존재하지 않는 하자 정보입니다."),
 
     // Estimate
-    ESTIMATE_001(HttpStatus.BAD_REQUEST, "ESTIMATE_001", "견적 요청 생성에 실패했습니다."),
+    ESTIMATE_001(HttpStatus.INTERNAL_SERVER_ERROR, "ESTIMATE_001", "견적 요청 생성에 실패했습니다."),
     ESTIMATE_002(HttpStatus.NOT_FOUND, "ESTIMATE_002", "존재하지 않는 견적 요청입니다."),
     ESTIMATE_003(HttpStatus.FORBIDDEN, "ESTIMATE_003", "해당 견적 요청에 접근 권한이 없습니다."),
 

--- a/src/main/java/com/roomlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/roomlog/global/exception/ErrorCode.java
@@ -46,7 +46,8 @@ public enum ErrorCode {
     REPAIR_001(HttpStatus.NOT_FOUND, "REPAIR_001", "존재하지 않는 수리 내역입니다."),
 
     // RepairShop
-    REPAIRSHOP_001(HttpStatus.NOT_FOUND, "REPAIRSHOP_001", "추천 가능한 수리 업체가 없습니다.");
+    REPAIRSHOP_001(HttpStatus.NOT_FOUND, "REPAIRSHOP_001", "추천 가능한 수리 업체가 없습니다."),
+    REPAIRSHOP_002(HttpStatus.NOT_FOUND, "REPAIRSHOP_002", "업체 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/roomlog/global/infra/KakaoLocalClient.java
+++ b/src/main/java/com/roomlog/global/infra/KakaoLocalClient.java
@@ -1,0 +1,96 @@
+package com.roomlog.global.infra;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoLocalClient {
+
+    private static final String ADDRESS_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String KEYWORD_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
+
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.api-key}")
+    private String apiKey;
+
+    public double[] geocodeAddress(String address) {
+        String url = UriComponentsBuilder.fromHttpUrl(ADDRESS_SEARCH_URL)
+                .queryParam("query", address)
+                .build().toUriString();
+
+        ResponseEntity<AddressSearchResponse> response = restTemplate.exchange(
+                url, HttpMethod.GET, authHeader(), AddressSearchResponse.class);
+
+        List<AddressDocument> documents = response.getBody().getDocuments();
+        if (documents == null || documents.isEmpty()) {
+            return null;
+        }
+        AddressDocument doc = documents.get(0);
+        return new double[]{Double.parseDouble(doc.getY()), Double.parseDouble(doc.getX())};
+    }
+
+    public List<KakaoPlace> searchKeyword(String keyword, double lat, double lng, int radiusMeters, String sort) {
+        String url = UriComponentsBuilder.fromHttpUrl(KEYWORD_SEARCH_URL)
+                .queryParam("query", keyword)
+                .queryParam("x", lng)
+                .queryParam("y", lat)
+                .queryParam("radius", Math.min(radiusMeters, 20000))
+                .queryParam("sort", sort != null ? sort : "distance")
+                .build().toUriString();
+
+        ResponseEntity<KeywordSearchResponse> response = restTemplate.exchange(
+                url, HttpMethod.GET, authHeader(), KeywordSearchResponse.class);
+
+        return response.getBody().getDocuments();
+    }
+
+    private HttpEntity<Void> authHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + apiKey);
+        return new HttpEntity<>(headers);
+    }
+
+    @Getter
+    public static class AddressSearchResponse {
+        private List<AddressDocument> documents;
+    }
+
+    @Getter
+    public static class AddressDocument {
+        private String x;
+        private String y;
+    }
+
+    @Getter
+    public static class KeywordSearchResponse {
+        private List<KakaoPlace> documents;
+    }
+
+    @Getter
+    public static class KakaoPlace {
+        private String id;
+        @JsonProperty("place_name")
+        private String placeName;
+        private String phone;
+        @JsonProperty("road_address_name")
+        private String roadAddressName;
+        @JsonProperty("address_name")
+        private String addressName;
+        private String x;
+        private String y;
+        private String distance;
+    }
+}

--- a/src/main/java/com/roomlog/global/infra/KakaoLocalClient.java
+++ b/src/main/java/com/roomlog/global/infra/KakaoLocalClient.java
@@ -57,6 +57,19 @@ public class KakaoLocalClient {
         return response.getBody().getDocuments();
     }
 
+    public KakaoPlace getPlaceById(String placeId) {
+        String url = UriComponentsBuilder.fromHttpUrl("https://dapi.kakao.com/v2/local/place/id.json")
+                .queryParam("id", placeId)
+                .build().toUriString();
+
+        ResponseEntity<KeywordSearchResponse> response = restTemplate.exchange(
+                url, HttpMethod.GET, authHeader(), KeywordSearchResponse.class);
+
+        List<KakaoPlace> documents = response.getBody().getDocuments();
+        if (documents == null || documents.isEmpty()) return null;
+        return documents.get(0);
+    }
+
     private HttpEntity<Void> authHeader() {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "KakaoAK " + apiKey);

--- a/src/main/java/com/roomlog/global/infra/SmsService.java
+++ b/src/main/java/com/roomlog/global/infra/SmsService.java
@@ -1,0 +1,45 @@
+package com.roomlog.global.infra;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SmsService {
+
+    @Value("${solapi.api-key}")
+    private String apiKey;
+
+    @Value("${solapi.api-secret}")
+    private String apiSecret;
+
+    @Value("${solapi.sender}")
+    private String sender;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.solapi.com");
+    }
+
+    public boolean send(String to, String text) {
+        try {
+            Message message = new Message();
+            message.setFrom(sender);
+            message.setTo(to);
+            message.setText(text);
+            messageService.sendOne(new SingleMessageSendingRequest(message));
+            return true;
+        } catch (Exception e) {
+            log.error("SMS 전송 실패 to={}: {}", to, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,6 @@ jwt:
 
 ai:
   api-key: ${AI_API_KEY:roomlog-ai-secret-key}
+
+kakao:
+  api-key: ${KAKAO_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,8 @@ ai:
 
 kakao:
   api-key: ${KAKAO_API_KEY}
+
+solapi:
+  api-key: ${SOLAPI_API_KEY}
+  api-secret: ${SOLAPI_API_SECRET}
+  sender: ${SOLAPI_SENDER}


### PR DESCRIPTION
## 📌 작업 내용
- 수리 api 일부 개발 및 swagger에 서버 경로 고정

## 🛠 변경 사항
-  ymal 파일에 kakao api 추가 및 업체 평점 엔티티 삭제
- 업체 리스트 조회, 견적 미리보기 api 개발
- 견적 요청 보내기 (solapi 연동 완료, 테스트 x) api 구현
- 수리 api 일부 개발 및 swagger에 서버 경로 고정

## 🔗 관련 이슈
- Closes #

## ✅ 테스트
- [x] 정상 동작 확인
- [x] 에러 케이스 확인

## 📸 결과 (선택)
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repair shop discovery—users can now search for nearby repair shops based on damage analysis with filtering by type, radius, and sort options.
  * Added estimate preview functionality—users can review estimated costs and defect details before submitting to providers.
  * Added SMS notifications to providers when estimates are created.

* **Documentation**
  * Updated entity schema and error code documentation.

* **Chores**
  * Integrated third-party SMS and location services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->